### PR TITLE
More docs on span end() via review

### DIFF
--- a/Sources/Tracing/Span.swift
+++ b/Sources/Tracing/Span.swift
@@ -49,7 +49,7 @@ public protocol Span: AnyObject {
     /// End this `Span` at the given timestamp.
     ///
     /// ### Rules about ending Spans
-    /// A Span must be ended only ONCE. Ending a span multiple times or never at all is considered a programming error.
+    /// A Span must be ended only ONCE. Ending a Span multiple times or never at all is considered a programming error.
     ///
     /// A tracer implementation MAY decide to crash the application if e.g. running in debug mode and noticing such misuse.
     ///


### PR DESCRIPTION
We're basically saying the same as otel, but allowing tracers to do what they can/want to -- including the crashing in debug mode which we want to allow.