### PR TITLE
depend on 0.1.0 baggage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,7 @@ let package = Package(
         .library(name: "TracingOpenTelemetrySupport", targets: ["TracingOpenTelemetrySupport"]),
     ],
     dependencies: [
-        // FIXME: changes to https when public
-        .package(url: "git@github.com:apple/swift-distributed-tracing-baggage.git", from: "0.0.1"),
+        .package(url: "git@github.com:apple/swift-distributed-tracing-baggage.git", from: "0.1.0"),
     ],
     targets: [
         // ==== --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
All repos now have 0.1.0 which is a good number to release initially with 👍 