### PR TITLE
Add Key alias in NestedSpanAttributesProtocol

### DIFF
--- a/Sources/Tracing/Span.swift
+++ b/Sources/Tracing/Span.swift
@@ -169,6 +169,10 @@ extension NestedSpanAttributesProtocol {
     }
 }
 
+extension NestedSpanAttributesProtocol {
+    public typealias Key = SpanAttributeKey
+}
+
 extension SpanAttributeNamespace {
     public subscript<T>(dynamicMember dynamicMember: KeyPath<NestedSpanAttributes, SpanAttributeKey<T>>) -> T?
         where T: SpanAttributeConvertible {

--- a/Sources/TracingOpenTelemetrySupport/SpanAttribute+EndUser.swift
+++ b/Sources/TracingOpenTelemetrySupport/SpanAttribute+EndUser.swift
@@ -53,14 +53,14 @@ public struct EndUserAttributes: SpanAttributeNamespace {
         public init() {}
 
         /// Username or client_id extracted from the access token or Authorization header in the inbound request from outside the system.
-        public var id: SpanAttribute.Key<String> { .init(name: SpanAttributeName.EndUser.id) }
+        public var id: Key<String> { .init(name: SpanAttributeName.EndUser.id) }
 
         /// Actual/assumed role the client is making the request under extracted from token or application security context.
-        public var role: SpanAttribute.Key<String> { .init(name: SpanAttributeName.EndUser.role) }
+        public var role: Key<String> { .init(name: SpanAttributeName.EndUser.role) }
 
         /// Scopes or granted authorities the client currently possesses extracted from token or application security context.
         /// The value would come from the scope associated with an OAuth 2.0 Access Token or an attribute value in a SAML 2.0 Assertion.
-        public var scope: SpanAttribute.Key<String> { .init(name: SpanAttributeName.EndUser.scope) }
+        public var scope: Key<String> { .init(name: SpanAttributeName.EndUser.scope) }
     }
 }
 #endif

--- a/Sources/TracingOpenTelemetrySupport/SpanAttribute+GRPCSemantics.swift
+++ b/Sources/TracingOpenTelemetrySupport/SpanAttribute+GRPCSemantics.swift
@@ -55,18 +55,18 @@ public struct GRPCAttributes: SpanAttributeNamespace {
         public init() {}
 
         /// The type of message, e.g. "SENT" or "RECEIVED".
-        public var messageType: SpanAttribute.Key<String> { .init(name: SpanAttributeName.GRPC.messageType) }
+        public var messageType: Key<String> { .init(name: SpanAttributeName.GRPC.messageType) }
 
         /// The message id calculated as two different counters starting from 1, one for sent messages and one for received messages.
-        public var messageID: SpanAttribute.Key<Int> { .init(name: SpanAttributeName.GRPC.messageID) }
+        public var messageID: Key<Int> { .init(name: SpanAttributeName.GRPC.messageID) }
 
         /// The compressed message size in bytes.
-        public var messageCompressedSize: SpanAttribute.Key<Int> {
+        public var messageCompressedSize: Key<Int> {
             .init(name: SpanAttributeName.GRPC.messageCompressedSize)
         }
 
         /// The uncompressed message size in bytes.
-        public var messageUncompressedSize: SpanAttribute.Key<Int> {
+        public var messageUncompressedSize: Key<Int> {
             .init(name: SpanAttributeName.GRPC.messageUncompressedSize)
         }
     }

--- a/Sources/TracingOpenTelemetrySupport/SpanAttribute+HTTPSemantics.swift
+++ b/Sources/TracingOpenTelemetrySupport/SpanAttribute+HTTPSemantics.swift
@@ -79,68 +79,68 @@ public struct HTTPAttributes: SpanAttributeNamespace {
         public init() {}
 
         /// HTTP request method. E.g. "GET".
-        public var method: SpanAttribute.Key<String> { .init(name: SpanAttributeName.HTTP.method) }
+        public var method: Key<String> { .init(name: SpanAttributeName.HTTP.method) }
 
         /// Full HTTP request URL in the form scheme://host[:port]/path?query[#fragment].
         /// Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
-        public var url: SpanAttribute.Key<String> { .init(name: SpanAttributeName.HTTP.url) }
+        public var url: Key<String> { .init(name: SpanAttributeName.HTTP.url) }
 
         /// The full request target as passed in a HTTP request line or equivalent, e.g. "/path/12314/?q=ddds#123".
-        public var target: SpanAttribute.Key<String> { .init(name: SpanAttributeName.HTTP.target) }
+        public var target: Key<String> { .init(name: SpanAttributeName.HTTP.target) }
 
         /// The value of the HTTP host header. When the header is empty or not present, this attribute should be the same.
-        public var host: SpanAttribute.Key<String> { .init(name: SpanAttributeName.HTTP.host) }
+        public var host: Key<String> { .init(name: SpanAttributeName.HTTP.host) }
 
         /// The URI scheme identifying the used protocol: "http" or "https"
-        public var scheme: SpanAttribute.Key<String> { .init(name: SpanAttributeName.HTTP.scheme) }
+        public var scheme: Key<String> { .init(name: SpanAttributeName.HTTP.scheme) }
 
         /// HTTP response status code. E.g. 200.
-        public var statusCode: SpanAttribute.Key<Int> { .init(name: SpanAttributeName.HTTP.statusCode) }
+        public var statusCode: Key<Int> { .init(name: SpanAttributeName.HTTP.statusCode) }
 
         /// HTTP reason phrase. E.g. "OK".
-        public var statusText: SpanAttribute.Key<String> { .init(name: SpanAttributeName.HTTP.statusText) }
+        public var statusText: Key<String> { .init(name: SpanAttributeName.HTTP.statusText) }
 
         /// Kind of HTTP protocol used: "1.0", "1.1", "2", "SPDY" or "QUIC".
-        public var flavor: SpanAttribute.Key<String> { .init(name: SpanAttributeName.HTTP.flavor) }
+        public var flavor: Key<String> { .init(name: SpanAttributeName.HTTP.flavor) }
 
         /// Value of the HTTP User-Agent header sent by the client.
-        public var userAgent: SpanAttribute.Key<String> { .init(name: SpanAttributeName.HTTP.userAgent) }
+        public var userAgent: Key<String> { .init(name: SpanAttributeName.HTTP.userAgent) }
 
         /// The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often,
         /// but not always, present as the Content-Length header. For requests using transport encoding, this should be the
         /// compressed size.
-        public var requestContentLength: SpanAttribute.Key<Int> {
+        public var requestContentLength: Key<Int> {
             .init(name: SpanAttributeName.HTTP.requestContentLength)
         }
 
         /// The size of the uncompressed request payload body after transport decoding. Not set if transport encoding not used.
-        public var requestContentLengthUncompressed: SpanAttribute.Key<Int> {
+        public var requestContentLengthUncompressed: Key<Int> {
             .init(name: SpanAttributeName.HTTP.requestContentLengthUncompressed)
         }
 
         /// The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and
         /// is often, but not always, present as the Content-Length header. For requests using transport encoding, this
         /// should be the compressed size.
-        public var responseContentLength: SpanAttribute.Key<Int> {
+        public var responseContentLength: Key<Int> {
             .init(name: SpanAttributeName.HTTP.responseContentLength)
         }
 
         /// The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used.
-        public var responseContentLengthUncompressed: SpanAttribute.Key<Int> {
+        public var responseContentLengthUncompressed: Key<Int> {
             .init(name: SpanAttributeName.HTTP.responseContentLengthUncompressed)
         }
 
         /// The primary server name of the matched virtual host. This should be obtained via configuration.
         /// If no such configuration can be obtained, this attribute MUST NOT be set (`net.hostName` should be used instead).
-        public var serverName: SpanAttribute.Key<String> { .init(name: SpanAttributeName.HTTP.serverName) }
+        public var serverName: Key<String> { .init(name: SpanAttributeName.HTTP.serverName) }
 
         /// The matched route (path template). E.g. "/users/:userID?".
-        public var serverRoute: SpanAttribute.Key<String> { .init(name: SpanAttributeName.HTTP.serverRoute) }
+        public var serverRoute: Key<String> { .init(name: SpanAttributeName.HTTP.serverRoute) }
 
         /// The IP address of the original client behind all proxies, if known (e.g. from X-Forwarded-For).
         /// Note that this is not necessarily the same as `net.peerIP`, which would identify the network-level peer,
         /// which may be a proxy.
-        public var serverClientIP: SpanAttribute.Key<String> { .init(name: SpanAttributeName.HTTP.serverClientIP) }
+        public var serverClientIP: Key<String> { .init(name: SpanAttributeName.HTTP.serverClientIP) }
     }
 }
 #endif

--- a/Sources/TracingOpenTelemetrySupport/SpanAttribute+NetSemantics.swift
+++ b/Sources/TracingOpenTelemetrySupport/SpanAttribute+NetSemantics.swift
@@ -61,25 +61,25 @@ public struct NetAttributes: SpanAttributeNamespace {
         public init() {}
 
         /// Transport protocol used.
-        public var transport: SpanAttribute.Key<String> { .init(name: SpanAttributeName.Net.transport) }
+        public var transport: Key<String> { .init(name: SpanAttributeName.Net.transport) }
 
         /// Remote address of the peer (dotted decimal for IPv4 or RFC5952 for IPv6).
-        public var peerIP: SpanAttribute.Key<String> { .init(name: SpanAttributeName.Net.peerIP) }
+        public var peerIP: Key<String> { .init(name: SpanAttributeName.Net.peerIP) }
 
         /// Remote port number as an integer. E.g., 80.
-        public var peerPort: SpanAttribute.Key<Int> { .init(name: SpanAttributeName.Net.peerPort) }
+        public var peerPort: Key<Int> { .init(name: SpanAttributeName.Net.peerPort) }
 
         /// Remote hostname or similar.
-        public var peerName: SpanAttribute.Key<String> { .init(name: SpanAttributeName.Net.peerName) }
+        public var peerName: Key<String> { .init(name: SpanAttributeName.Net.peerName) }
 
         /// Like `peerIP` but for the host IP. Useful in case of a multi-IP host.
-        public var hostIP: SpanAttribute.Key<String> { .init(name: SpanAttributeName.Net.hostIP) }
+        public var hostIP: Key<String> { .init(name: SpanAttributeName.Net.hostIP) }
 
         /// Like `peerPort` but for the host port.
-        public var hostPort: SpanAttribute.Key<Int> { .init(name: SpanAttributeName.Net.hostPort) }
+        public var hostPort: Key<Int> { .init(name: SpanAttributeName.Net.hostPort) }
 
         /// Local hostname or similar.
-        public var hostName: SpanAttribute.Key<String> { .init(name: SpanAttributeName.Net.hostName) }
+        public var hostName: Key<String> { .init(name: SpanAttributeName.Net.hostName) }
     }
 }
 #endif

--- a/Sources/TracingOpenTelemetrySupport/SpanAttribute+PeerSemantics.swift
+++ b/Sources/TracingOpenTelemetrySupport/SpanAttribute+PeerSemantics.swift
@@ -49,7 +49,7 @@ public struct PeerAttributes: SpanAttributeNamespace {
         public init() {}
 
         /// The service.name of the remote service. SHOULD be equal to the actual service.name resource attribute of the remote service if any.
-        public var service: SpanAttribute.Key<String> { .init(name: SpanAttributeName.Peer.service) }
+        public var service: Key<String> { .init(name: SpanAttributeName.Peer.service) }
     }
 }
 #endif

--- a/Sources/TracingOpenTelemetrySupport/SpanAttribute+RPCSemantics.swift
+++ b/Sources/TracingOpenTelemetrySupport/SpanAttribute+RPCSemantics.swift
@@ -53,13 +53,13 @@ public struct RPCAttributes: SpanAttributeNamespace {
         public init() {}
 
         /// A string identifying the remoting system, e.g., "grpc", "java_rmi" or "wcf".
-        public var system: SpanAttribute.Key<String> { .init(name: SpanAttributeName.RPC.system) }
+        public var system: Key<String> { .init(name: SpanAttributeName.RPC.system) }
 
         /// The full name of the service being called, including its package name, if applicable.
-        public var service: SpanAttribute.Key<String> { .init(name: SpanAttributeName.RPC.service) }
+        public var service: Key<String> { .init(name: SpanAttributeName.RPC.service) }
 
         /// The name of the method being called, must be equal to the $method part in the span name.
-        public var method: SpanAttribute.Key<String> { .init(name: SpanAttributeName.RPC.method) }
+        public var method: Key<String> { .init(name: SpanAttributeName.RPC.method) }
     }
 }
 #endif

--- a/Tests/TracingTests/SpanTests.swift
+++ b/Tests/TracingTests/SpanTests.swift
@@ -229,15 +229,15 @@ public struct HTTPAttributes: SpanAttributeNamespace {
     public struct NestedSpanAttributes: NestedSpanAttributesProtocol {
         public init() {}
 
-        public var statusCode: SpanAttribute.Key<Int> {
+        public var statusCode: Key<Int> {
             "http.status_code"
         }
 
-        public var codesArray: SpanAttribute.Key<[Int]> {
+        public var codesArray: Key<[Int]> {
             "http.codes_array"
         }
 
-        public var customType: SpanAttribute.Key<CustomAttributeValue> {
+        public var customType: Key<CustomAttributeValue> {
             "http.custom_value"
         }
     }


### PR DESCRIPTION
As described in #10, this makes for a slightly nicer API when defining `SpanAttribute` constants.

- Closes #10 