### PR TITLE
The README file in this repo has a bad link - [404:NotFound]

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Thanks to tracing, and trace identifiers, even if not using tracing visualizatio
 
 **Passing context to client libraries**: When using client libraries that support distributed tracing, they will accept a `Baggage.LoggingContext` type as their _last_ parameter in many calls.
 
-When using client libraries that support distributed tracing, they will accept a `Baggage.LoggingContext` type as their _last_ parameter in many calls. Please refer to [Context argument naming/positioning](https://github.com/apple/swift-distributed-tracing/tree/wip-readme-release#context-propagation-by-explicit-loggingcontext-passing) in the [Context propagation](https://github.com/apple/swift-distributed-tracing/tree/wip-readme-release#context-propagation-by-explicit-loggingcontext-passing) section of this readme to learn more about how to properly pass context values around.
+When using client libraries that support distributed tracing, they will accept a `Baggage.LoggingContext` type as their _last_ parameter in many calls. Please refer to [Context argument naming/positioning](#context-propagation-by-explicit-loggingcontext-passing) in the [Context propagation](#context-propagation-by-explicit-loggingcontext-passing) section of this readme to learn more about how to properly pass context values around.
 
 ### Instrumenting your code
 


### PR DESCRIPTION
The markup version of the readme that is displayed for the main page in this repo contains the following bad link:

"Context argument naming/positioning" & “Context propagation”
Status code [404:NotFound] - Link: https://github.com/apple/swift-distributed-tracing/tree/wip-readme-release#context-propagation-by-explicit-loggingcontext-passing


They should just be: #context-propagation-by-explicit-loggingcontext-passing

**Extra**

This bad link was found by a tool I recently created as part of an new experimental hobby project: https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder

Re-check this Repo using the tool’s website: http://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3a%2f%2fgithub.com%2fapple%2fswift-distributed-tracing

If this has been helpful, or if you have any feedback on the tool itself, then please feel free to share your thoughts by adding a comment here, or adding to a “Discussion” in the tool’s Repo.