### PR TITLE
Overwrite image for docker-compose docs service

### DIFF
--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -14,3 +14,6 @@ services:
 
   shell:
     image: swift-distributed-tracing:18.04-5.0
+
+  docs:
+    image: swift-distributed-tracing:18.04-5.0

--- a/docker/docker-compose.1804.51.yaml
+++ b/docker/docker-compose.1804.51.yaml
@@ -16,3 +16,6 @@ services:
 
   shell:
     image: swift-distributed-tracing:18.04-5.1
+
+  docs:
+    image: swift-distributed-tracing:18.04-5.1

--- a/docker/docker-compose.1804.52.yaml
+++ b/docker/docker-compose.1804.52.yaml
@@ -16,3 +16,6 @@ services:
 
   shell:
     image: swift-distributed-tracing:18.04-5.2
+
+  docs:
+    image: swift-distributed-tracing:18.04-5.2

--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -15,3 +15,6 @@ services:
 
   shell:
     image: swift-distributed-tracing:18.04-5.3
+
+  docs:
+    image: swift-distributed-tracing:18.04-5.3

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       - $SSH_AUTH_SOCK:/tmp/ssh-agent:z
     environment: # FIXME: temp while private
       - SSH_AUTH_SOCK=/tmp/ssh-agent
-      - GIT_SSH_COMMAND=ssh -vv -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no    
+      - GIT_SSH_COMMAND=ssh -vv -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
     command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
 
   # util


### PR DESCRIPTION
Generating docs via `docker-compose` wasn't working because the image hasn't been overwritten in the `docker-compose-*.yaml` files. It fell back to fetching `swift-distributed-tracing:default` from Docker Hub which doesn't exist. By overwriting the image with a platform/version-specific tag, generating docs now works.