### PR TITLE
Remove UseCases dir from scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,2 @@
 .build/
 .swiftpm/
-UseCases/.build/
-UseCases/.swiftpm/

--- a/.swiftformat
+++ b/.swiftformat
@@ -2,7 +2,6 @@
 
 --swiftversion 5.0
 --exclude .build
---exclude UseCases/.build
 --exclude Tests/LinuxMain.swift
 --exclude **/*Tests+XCTest.swift
 

--- a/scripts/validate_format.sh
+++ b/scripts/validate_format.sh
@@ -21,7 +21,7 @@ printf "=> Checking format\n"
 FIRST_OUT="$(git status --porcelain)"
 # swiftformat does not scale so we loop ourselves
 shopt -u dotglob
-find Sources/* Tests/* IntegrationTests/* UseCases/* -type d | while IFS= read -r d; do
+find Sources/* Tests/* IntegrationTests/* -type d | while IFS= read -r d; do
   printf "   * checking $d... "
   out=$(swiftformat $d 2>&1)
   SECOND_OUT="$(git status --porcelain)"

--- a/scripts/validate_license_headers.sh
+++ b/scripts/validate_license_headers.sh
@@ -109,7 +109,6 @@ EOF
   (
     cd "$here/.."
     find . \
-      \( \! -path './UseCases/.build/*' -a \
       \( \! -path './.build/*' \) -a \
       \( "${matching_files[@]}" \) -a \
       \( \! \( "${exceptions[@]}" \) \) \) | while read line; do


### PR DESCRIPTION
The `UseCases` directory has been removed a while ago, but it was still included in some scripts.