### PR TITLE
Drop 'Bagagge' in docs script

### DIFF
--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -68,7 +68,7 @@ jazzy_args=(--clean
             --theme fullwidth
             --xcodebuild-arguments -scheme,$project_xcodeproj_name-Package)
 cat > "$module_switcher" <<"EOF"
-# Swift Distributed Tracing Baggage Docs
+# Swift Distributed Tracing Docs
 
 This project contains modules:
 EOF


### PR DESCRIPTION
`generate_docs.sh` used "Swift Distributed Tracing Baggage Docs" as the title. Now the 'Baggage' part is dropped.