### PR TITLE
Add async versions of `withSpan` API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "TracingOpenTelemetrySupport", targets: ["TracingOpenTelemetrySupport"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-distributed-tracing-baggage.git", from: "0.1.1")
+        .package(url: "https://github.com/apple/swift-distributed-tracing-baggage.git", .branch("async")),
     ],
     targets: [
         // ==== --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Adds support for creating spans in an async context with automatic "baggage propagation" through task locals.