### PR TITLE
Adjust API Availability for Structured Concurrency Backport

### DIFF
--- a/Sources/Tracing/Tracer.swift
+++ b/Sources/Tracing/Tracer.swift
@@ -97,7 +97,7 @@ extension Tracer {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Starting spans: Task-local Baggage propagation
 
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Tracer {
     /// Execute the given operation within a newly created `Span`,

--- a/Sources/Tracing/Tracer.swift
+++ b/Sources/Tracing/Tracer.swift
@@ -98,7 +98,7 @@ extension Tracer {
 // MARK: Starting spans: Task-local Baggage propagation
 
 #if swift(>=5.5)
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Tracer {
     /// Execute the given operation within a newly created `Span`,
     /// started as a child of the currently stored task local `Baggage.current` or as a root span if `nil`.

--- a/Tests/TracingTests/TracerTests.swift
+++ b/Tests/TracingTests/TracerTests.swift
@@ -98,8 +98,8 @@ final class TracerTests: XCTestCase {
     }
 
     func testWithSpan_automaticBaggagePropagation_sync() throws {
-        #if swift(>=5.5)
-        guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else {
+        #if swift(>=5.5) && canImport(_Concurrency)
+        guard #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else {
             throw XCTSkip("Task locals are not supported on this platform.")
         }
 
@@ -127,8 +127,8 @@ final class TracerTests: XCTestCase {
     }
 
     func testWithSpan_automaticBaggagePropagation_sync_throws() throws {
-        #if swift(>=5.5)
-        guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else {
+        #if swift(>=5.5) && canImport(_Concurrency)
+        guard #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else {
             throw XCTSkip("Task locals are not supported on this platform.")
         }
 
@@ -157,8 +157,8 @@ final class TracerTests: XCTestCase {
     }
 
     func testWithSpan_automaticBaggagePropagation_async() throws {
-        #if swift(>=5.5)
-        guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else {
+        #if swift(>=5.5) && canImport(_Concurrency)
+        guard #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else {
             throw XCTSkip("Task locals are not supported on this platform.")
         }
 
@@ -188,8 +188,8 @@ final class TracerTests: XCTestCase {
     }
 
     func testWithSpan_automaticBaggagePropagation_async_throws() throws {
-        #if swift(>=5.5)
-        guard #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) else {
+        #if swift(>=5.5) && canImport(_Concurrency)
+        guard #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else {
             throw XCTSkip("Task locals are not supported on this platform.")
         }
 
@@ -219,7 +219,7 @@ final class TracerTests: XCTestCase {
         #endif
     }
 
-    #if swift(>=5.5)
+    #if swift(>=5.5) && canImport(_Concurrency)
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     /// Helper method to execute async operations until we can use async tests (currently incompatible with the generated LinuxMain file).
     /// - Parameter operation: The operation to test.

--- a/Tests/TracingTests/TracerTests.swift
+++ b/Tests/TracingTests/TracerTests.swift
@@ -220,7 +220,7 @@ final class TracerTests: XCTestCase {
     }
 
     #if swift(>=5.5)
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     /// Helper method to execute async operations until we can use async tests (currently incompatible with the generated LinuxMain file).
     /// - Parameter operation: The operation to test.
     func testAsync(_ operation: @escaping () async throws -> Void) rethrows {


### PR DESCRIPTION
*Waiting for merge of https://github.com/apple/swift-distributed-tracing-baggage/pull/18 so we can update the dependency version.*

As the Swift Structured Concurrency backport is now available with the [release of Xcode 13.2](https://developer.apple.com/documentation/xcode-release-notes/xcode-13_2-release-notes), I adjusted the API availability guards to enable these features on previous OS versions.