### PR TITLE
+span additional withSpan to ease entering async world from non-async world

### DIFF
--- a/Sources/Tracing/Tracer.swift
+++ b/Sources/Tracing/Tracer.swift
@@ -166,11 +166,11 @@ extension Tracer {
     /// - Throws: the error the `operation` has thrown (if any)
     public func withSpan<T>(
         _ operationName: String,
-        baggage: Baggage?,
+        baggage: Baggage,
         ofKind kind: SpanKind = .internal,
         _ operation: (Span) async throws -> T
     ) async rethrows -> T {
-        let span = self.startSpan(operationName, baggage: baggage ?? .topLevel, ofKind: kind)
+        let span = self.startSpan(operationName, baggage: baggage, ofKind: kind)
         defer { span.end() }
         do {
             return try await Baggage.$current.withValue(span.baggage) {

--- a/Tests/TracingTests/TracerTests+XCTest.swift
+++ b/Tests/TracingTests/TracerTests+XCTest.swift
@@ -33,6 +33,7 @@ extension TracerTests {
                 ("testWithSpan_automaticBaggagePropagation_sync", testWithSpan_automaticBaggagePropagation_sync),
                 ("testWithSpan_automaticBaggagePropagation_sync_throws", testWithSpan_automaticBaggagePropagation_sync_throws),
                 ("testWithSpan_automaticBaggagePropagation_async", testWithSpan_automaticBaggagePropagation_async),
+                ("testWithSpan_enterFromNonAsyncCode_passBaggage_asyncOperation", testWithSpan_enterFromNonAsyncCode_passBaggage_asyncOperation),
                 ("testWithSpan_automaticBaggagePropagation_async_throws", testWithSpan_automaticBaggagePropagation_async_throws),
            ]
    }

--- a/Tests/TracingTests/TracerTests.swift
+++ b/Tests/TracingTests/TracerTests.swift
@@ -187,8 +187,7 @@ final class TracerTests: XCTestCase {
         #endif
     }
 
-
-    func testWithSpan_enterFromNonAsyncCode_passBaggage_asyncOperation() async throws {
+    func testWithSpan_enterFromNonAsyncCode_passBaggage_asyncOperation() throws {
         #if swift(>=5.5) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else {
             throw XCTSkip("Task locals are not supported on this platform.")
@@ -207,16 +206,18 @@ final class TracerTests: XCTestCase {
             "world"
         }
 
-        var fromNonAsyncWorld = Baggage.topLevel
-        fromNonAsyncWorld.traceID = "1234-5678"
-        let value = await tracer.withSpan("hello", baggage: fromNonAsyncWorld) { (span: Span) -> String in
-            XCTAssertEqual(span.baggage.traceID, Baggage.current?.traceID)
-            XCTAssertEqual(span.baggage.traceID, fromNonAsyncWorld.traceID)
-            return await operation(span: span)
-        }
+        self.testAsync {
+            var fromNonAsyncWorld = Baggage.topLevel
+            fromNonAsyncWorld.traceID = "1234-5678"
+            let value = await tracer.withSpan("hello", baggage: fromNonAsyncWorld) { (span: Span) -> String in
+                XCTAssertEqual(span.baggage.traceID, Baggage.current?.traceID)
+                XCTAssertEqual(span.baggage.traceID, fromNonAsyncWorld.traceID)
+                return await operation(span: span)
+            }
 
-        XCTAssertEqual(value, "world")
-        XCTAssertTrue(spanEnded)
+            XCTAssertEqual(value, "world")
+            XCTAssertTrue(spanEnded)
+        }
         #endif
     }
 

--- a/Tests/TracingTests/TracerTests.swift
+++ b/Tests/TracingTests/TracerTests.swift
@@ -187,6 +187,39 @@ final class TracerTests: XCTestCase {
         #endif
     }
 
+
+    func testWithSpan_enterFromNonAsyncCode_passBaggage_asyncOperation() async throws {
+        #if swift(>=5.5) && canImport(_Concurrency)
+        guard #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else {
+            throw XCTSkip("Task locals are not supported on this platform.")
+        }
+
+        let tracer = TestTracer()
+        InstrumentationSystem.bootstrapInternal(tracer)
+        defer {
+            InstrumentationSystem.bootstrapInternal(nil)
+        }
+
+        var spanEnded = false
+        tracer.onEndSpan = { _ in spanEnded = true }
+
+        func operation(span: Span) async -> String {
+            "world"
+        }
+
+        var fromNonAsyncWorld = Baggage.topLevel
+        fromNonAsyncWorld.traceID = "1234-5678"
+        let value = await tracer.withSpan("hello", baggage: fromNonAsyncWorld) { (span: Span) -> String in
+            XCTAssertEqual(span.baggage.traceID, Baggage.current?.traceID)
+            XCTAssertEqual(span.baggage.traceID, fromNonAsyncWorld.traceID)
+            return await operation(span: span)
+        }
+
+        XCTAssertEqual(value, "world")
+        XCTAssertTrue(spanEnded)
+        #endif
+    }
+
     func testWithSpan_automaticBaggagePropagation_async_throws() throws {
         #if swift(>=5.5) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else {


### PR DESCRIPTION
I'm wondering if we need to offer this.

Just an idea for now, but I've hit this when calling swift code from C, where we could not have had set the task-local, so here we're "entering the async world". We could set the `Baggage` around the withSpan, but that means two levels of nesting and one task local set more than we actually need.