### PR TITLE
[Discussion] prototype converting span attributes into metadata

### DIFF
--- a/Sources/Tracing/Span.swift
+++ b/Sources/Tracing/Span.swift
@@ -269,7 +269,7 @@ public enum SpanAttribute: Equatable {
         .int(0)
     }
 
-    internal var anyValue: Any {
+    public var anyValue: Any {
         switch self {
         case .int(let value):
             return value


### PR DESCRIPTION
@fabianfett noticed he ended up with logs containing:

`<date> info what : http_flavor=string("1.1") http_method=string("GET") http_status_code=string("405 Method Not Allowed") http_target=string("/") [What] Some message`

which wrongly have those `string()` in there.

The code used to produce this was this:

```swift
     var metadata = Logger.Metadata()

        if let httpSpan = trace.httpSpan {
            if let method = httpSpan.attributes["http.method"] {
                metadata["http_method"] = "\(method.toSpanAttribute())"
            }
            if let route = httpSpan.attributes["http.route"] {
                metadata["http_route"] = "\(route)"
            }
       }
```

So this PR is to discuss what we should do about this.