### PR TITLE
Recording an error may carry attributes

### DIFF
--- a/Sources/Tracing/NoOpTracer.swift
+++ b/Sources/Tracing/NoOpTracer.swift
@@ -60,7 +60,7 @@ public struct NoOpTracer: Tracer {
 
         public func addEvent(_ event: SpanEvent) {}
 
-        public func recordError(_ error: Error) {}
+        public func recordError(_ error: Error, attributes: SpanAttributes) {}
 
         public var attributes: SpanAttributes {
             get {

--- a/Sources/Tracing/Span.swift
+++ b/Sources/Tracing/Span.swift
@@ -42,7 +42,7 @@ public protocol Span: AnyObject, _SwiftTracingSendableSpan {
     ///
     /// - Parameters:
     ///   - error: The error to be recorded.
-    func recordError(_ error: Error)
+    func recordError(_ error: Error, attributes: SpanAttributes)
 
     /// The attributes describing this `Span`.
     var attributes: SpanAttributes { get set }
@@ -94,6 +94,12 @@ extension Span {
     /// - Parameter attributes: The ``SpanAttributes`` describing this link. Defaults to no attributes.
     public func addLink(_ other: Span, attributes: SpanAttributes = [:]) {
         self.addLink(SpanLink(baggage: other.baggage, attributes: attributes))
+    }
+}
+
+extension Span {
+    public func recordError(_ error: Error) {
+        self.recordError(error, attributes: [:])
     }
 }
 

--- a/Sources/Tracing/Span.swift
+++ b/Sources/Tracing/Span.swift
@@ -99,6 +99,10 @@ extension Span {
 }
 
 extension Span {
+    /// Record a failure described by the given error.
+    ///
+    /// - Parameters:
+    ///   - error: The error to be recorded.
     public func recordError(_ error: Error) {
         self.recordError(error, attributes: [:])
     }

--- a/Sources/Tracing/Span.swift
+++ b/Sources/Tracing/Span.swift
@@ -42,6 +42,7 @@ public protocol Span: AnyObject, _SwiftTracingSendableSpan {
     ///
     /// - Parameters:
     ///   - error: The error to be recorded.
+    ///   - attributes: Additional attributes describing the error.
     func recordError(_ error: Error, attributes: SpanAttributes)
 
     /// The attributes describing this `Span`.

--- a/Tests/TracingTests/DynamicTracepointTracerTests.swift
+++ b/Tests/TracingTests/DynamicTracepointTracerTests.swift
@@ -276,7 +276,7 @@ extension DynamicTracepointTestTracer {
             // nothing
         }
 
-        func recordError(_ error: Error) {
+        func recordError(_ error: Error, attributes: SpanAttributes) {
             print("")
         }
 

--- a/Tests/TracingTests/TestTracer.swift
+++ b/Tests/TracingTests/TestTracer.swift
@@ -21,7 +21,7 @@ import Tracing
 /// Only intended to be used in single-threaded testing.
 final class TestTracer: Tracer {
     private(set) var spans = [TestSpan]()
-    var onEndSpan: (Span) -> Void = { _ in }
+    var onEndSpan: (TestSpan) -> Void = { _ in }
 
     func startSpan(
         _ operationName: String,
@@ -104,6 +104,8 @@ final class TestSpan: Span {
     private let startTime: DispatchWallTime
     private(set) var endTime: DispatchWallTime?
 
+    private(set) var recordedErrors: [(Error, SpanAttributes)] = []
+
     let baggage: Baggage
 
     private(set) var events = [SpanEvent]() {
@@ -122,14 +124,14 @@ final class TestSpan: Span {
 
     private(set) var isRecording = false
 
-    let onEnd: (Span) -> Void
+    let onEnd: (TestSpan) -> Void
 
     init(
         operationName: String,
         startTime: DispatchWallTime,
         baggage: Baggage,
         kind: SpanKind,
-        onEnd: @escaping (Span) -> Void
+        onEnd: @escaping (TestSpan) -> Void
     ) {
         self.operationName = operationName
         self.startTime = startTime
@@ -151,7 +153,9 @@ final class TestSpan: Span {
         self.events.append(event)
     }
 
-    func recordError(_ error: Error) {}
+    func recordError(_ error: Error, attributes: SpanAttributes) {
+        self.recordedErrors.append((error, attributes))
+    }
 
     func end(at time: DispatchWallTime) {
         self.endTime = time

--- a/Tests/TracingTests/TracedLockTests.swift
+++ b/Tests/TracingTests/TracedLockTests.swift
@@ -151,7 +151,7 @@ private final class TracedLockPrintlnTracer: Tracer {
             self.events.append(event)
         }
 
-        func recordError(_ error: Error) {}
+        func recordError(_ error: Error, attributes: SpanAttributes) {}
 
         func end(at time: DispatchWallTime) {
             self.endTime = time

--- a/Tests/TracingTests/TracerTests+XCTest.swift
+++ b/Tests/TracingTests/TracerTests+XCTest.swift
@@ -35,6 +35,7 @@ extension TracerTests {
                 ("testWithSpan_automaticBaggagePropagation_async", testWithSpan_automaticBaggagePropagation_async),
                 ("testWithSpan_enterFromNonAsyncCode_passBaggage_asyncOperation", testWithSpan_enterFromNonAsyncCode_passBaggage_asyncOperation),
                 ("testWithSpan_automaticBaggagePropagation_async_throws", testWithSpan_automaticBaggagePropagation_async_throws),
+                ("testWithSpan_recordErrorWithAttributes", testWithSpan_recordErrorWithAttributes),
            ]
    }
 }


### PR DESCRIPTION
**Motivation:**
It can be used to attach more information bout the error, like its stacktrace and similar information.

This is also supported by the otel spec, so we're aligning closer with it here.

**Modifications:**

Change the recordError to accept optional span attributes

**Result:**

more powerful record error API

resolves https://github.com/apple/swift-distributed-tracing/issues/45