### PR TITLE
associated type Span, Tracer as short-hand, and *Protocol types

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,12 @@ import PackageDescription
 
 let package = Package(
     name: "swift-distributed-tracing",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+    ],
     products: [
         .library(name: "Instrumentation", targets: ["Instrumentation"]),
         .library(name: "Tracing", targets: ["Tracing"]),

--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -3,6 +3,12 @@ import PackageDescription
 
 let package = Package(
     name: "swift-distributed-tracing",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+    ],
     products: [
         .library(name: "Instrumentation", targets: ["Instrumentation"]),
         .library(name: "Tracing", targets: ["Tracing"]),

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -3,6 +3,12 @@ import PackageDescription
 
 let package = Package(
     name: "swift-distributed-tracing",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+    ],
     products: [
         .library(name: "Instrumentation", targets: ["Instrumentation"]),
         .library(name: "Tracing", targets: ["Tracing"]),

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -3,6 +3,12 @@ import PackageDescription
 
 let package = Package(
     name: "swift-distributed-tracing",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+    ],
     products: [
         .library(name: "Instrumentation", targets: ["Instrumentation"]),
         .library(name: "Tracing", targets: ["Tracing"]),

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -3,6 +3,12 @@ import PackageDescription
 
 let package = Package(
     name: "swift-distributed-tracing",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+    ],
     products: [
         .library(name: "Instrumentation", targets: ["Instrumentation"]),
         .library(name: "Tracing", targets: ["Tracing"]),

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ This project uses the context progagation type defined independently in:
     + [Instrumenting your software](#library-framework-developers--instrumenting-your-software)
     + [Extracting & injecting Baggage](#extracting--injecting-baggage)
     + [Tracing your library](#tracing-your-library)
-* In-Depth Guide for: **Instrument developers**
-    + [Creating an `Instrument`](#instrument-developers--creating-an-instrument)
+* In-Depth Guide for: **InstrumentProtocol developers**
+    + [Creating an `InstrumentProtocol`](#instrument-developers--creating-an-instrument)
     + [Creating a `Tracer`](#creating-a--tracer-)
 * [Contributing](#contributing)
 
@@ -119,7 +119,7 @@ To your main target, add a dependency on `Tracing` library and the instrument yo
 ),
 ```
 
-Then (in an application, libraries should _never_ invoke `bootstrap`), you will want to bootstrap the specific tracer you want to use in your application. A `Tracer` is a type of `Instrument` and can be offered used to globally bootstrap the tracing system, like this:
+Then (in an application, libraries should _never_ invoke `bootstrap`), you will want to bootstrap the specific tracer you want to use in your application. A `Tracer` is a type of `InstrumentProtocol` and can be offered used to globally bootstrap the tracing system, like this:
 
 
 ```swift
@@ -261,7 +261,7 @@ When instrumenting server applications there are typically three parties involve
 
 1. [Application developers](#application-developers-setting-up-instruments) creating server-side applications
 2. [Library/Framework developers](#libraryframework-developers-instrumenting-your-software) providing building blocks to create these applications
-3. [Instrument developers](#instrument-developers-creating-an-instrument) providing tools to collect distributed metadata about your application
+3. [InstrumentProtocol developers](#instrument-developers-creating-an-instrument) providing tools to collect distributed metadata about your application
 
 For applications to be instrumented correctly these three parts have to play along nicely.
 
@@ -295,7 +295,7 @@ To your main target, add a dependency on the `Instrumentation library` and the i
 
 Instead of providing each instrumented library with a specific instrument explicitly, you *bootstrap* the
 `InstrumentationSystem` which acts as a singleton that libraries/frameworks access when calling out to the configured
-`Instrument`:
+`InstrumentProtocol`:
 
 ```swift
 InstrumentationSystem.bootstrap(FancyInstrument())
@@ -316,7 +316,7 @@ This is because tracing systems may attempt to emit metrics about their status e
 
 #### Bootstrapping multiple instruments using MultiplexInstrument
 
-It is important to note that `InstrumentationSystem.bootstrap(_: Instrument)` must only be called once. In case you
+It is important to note that `InstrumentationSystem.bootstrap(_: InstrumentProtocol)` must only be called once. In case you
 want to bootstrap the system to use multiple instruments, you group them in a `MultiplexInstrument` first, which you
 then pass along to the `bootstrap` method like this:
 
@@ -444,7 +444,7 @@ Spans form hierarchies with their parent spans, and end up being visualized usin
 The above trace is achieved by starting and ending spans in all the mentioned functions, for example, like this:
 
 ```swift
-let tracer: Tracer
+let tracer: any TracerProtocol
 
 func makeDinner(context: LoggingContext) async throws -> Meal {
   tracer.withSpan(operationName: "makeDinner", context) {
@@ -481,7 +481,7 @@ func get(url: String, context: LoggingContext) {
 }
 ```
 
-On the receiving side, an HTTP server should use the following `Instrument` API to extract the HTTP headers of the given
+On the receiving side, an HTTP server should use the following `InstrumentProtocol` API to extract the HTTP headers of the given
 `HTTPRequest` into:
 
 ```swift
@@ -536,12 +536,12 @@ func get(url: String, context: LoggingContext) {
 > In the above example we used the semantic `http.method` attribute that gets exposed via the
 `TracingOpenTelemetrySupport` library.
 
-## Instrument developers: Creating an instrument
+## InstrumentProtocol developers: Creating an instrument
 
-Creating an instrument means adopting the `Instrument` protocol (or `Tracer` in case you develop a tracer).
-`Instrument` is part of the `Instrumentation` library & `Tracing` contains the `Tracer` protocol.
+Creating an instrument means adopting the `InstrumentProtocol` protocol (or `Tracer` in case you develop a tracer).
+`InstrumentProtocol` is part of the `Instrumentation` library & `Tracing` contains the `Tracer` protocol.
 
-`Instrument` has two requirements:
+`InstrumentProtocol` has two requirements:
 
 1. A method to inject values inside a `LoggingContext` into a generic carrier (e.g. HTTP headers)
 2. A method to extract values from a generic carrier (e.g. HTTP headers) and store them in a `LoggingContext`

--- a/Sources/Instrumentation/Instrument.swift
+++ b/Sources/Instrumentation/Instrument.swift
@@ -50,9 +50,9 @@ public protocol Injector: _SwiftInstrumentationSendable {
 
 /// Conforming types are usually cross-cutting tools like tracers. They are agnostic of what specific `Carrier` is used
 /// to propagate metadata across boundaries, but instead just specify what values to use for which keys.
-public protocol Instrument: _SwiftInstrumentationSendable {
+public protocol InstrumentProtocol: _SwiftInstrumentationSendable {
     /// Extract values from a `Carrier` by using the given extractor and inject them into the given `Baggage`.
-    /// It's quite common for `Instrument`s to come up with new values if they weren't passed along in the given `Carrier`.
+    /// It's quite common for `InstrumentProtocol`s to come up with new values if they weren't passed along in the given `Carrier`.
     ///
     /// - Parameters:
     ///   - carrier: The `Carrier` that was used to propagate values across boundaries.

--- a/Sources/Instrumentation/InstrumentationSystem.swift
+++ b/Sources/Instrumentation/InstrumentationSystem.swift
@@ -57,7 +57,7 @@ public enum InstrumentationSystem {
     /// Returns the globally configured ``InstrumentProtocol``.
     ///
     /// Defaults to a no-op ``InstrumentProtocol`` if ``bootstrap(_:)`` wasn't called before.
-    public static var instrument: any InstrumentProtocol {
+    public static var instrument: InstrumentProtocol {
         self.lock.withReaderLock { self._instrument }
     }
 }

--- a/Sources/Instrumentation/InstrumentationSystem.swift
+++ b/Sources/Instrumentation/InstrumentationSystem.swift
@@ -15,23 +15,24 @@
 import InstrumentationBaggage
 
 /// `InstrumentationSystem` is a global facility where the default cross-cutting tool can be configured.
-/// It is set up just once in a given program to select the desired ``Instrument`` implementation.
+/// It is set up just once in a given program to select the desired ``InstrumentProtocol`` implementation.
 ///
 /// # Bootstrap multiple Instruments
 /// If you need to use more that one cross-cutting tool you can do so by using ``MultiplexInstrument``.
 ///
-/// # Access the Instrument
-/// ``instrument``: Returns whatever you passed to ``bootstrap(_:)`` as an ``Instrument``.
+/// # Access the InstrumentProtocol
+/// ``instrument``: Returns whatever you passed to ``bootstrap(_:)`` as an ``InstrumentProtocol``.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
 public enum InstrumentationSystem {
     private static let lock = ReadWriteLock()
-    private static var _instrument: Instrument = NoOpInstrument()
+    private static var _instrument: InstrumentProtocol = NoOpInstrument()
     private static var isInitialized = false
 
-    /// Globally select the desired ``Instrument`` implementation.
+    /// Globally select the desired ``InstrumentProtocol`` implementation.
     ///
-    /// - Parameter instrument: The ``Instrument`` you want to share globally within your system.
+    /// - Parameter instrument: The ``InstrumentProtocol`` you want to share globally within your system.
     /// - Warning: Do not call this method more than once. This will lead to a crash.
-    public static func bootstrap(_ instrument: Instrument) {
+    public static func bootstrap(_ instrument: InstrumentProtocol) {
         self.lock.withWriterLock {
             precondition(
                 !self.isInitialized, """
@@ -47,23 +48,24 @@ public enum InstrumentationSystem {
     /// For testing scenarios one may want to set instruments multiple times, rather than the set-once semantics enforced by ``bootstrap(_:)``.
     ///
     /// - Parameter instrument: the instrument to boostrap the system with, if `nil` the ``NoOpInstrument`` is bootstrapped.
-    internal static func bootstrapInternal(_ instrument: Instrument?) {
+    internal static func bootstrapInternal(_ instrument: InstrumentProtocol?) {
         self.lock.withWriterLock {
             self._instrument = instrument ?? NoOpInstrument()
         }
     }
 
-    /// Returns the globally configured ``Instrument``.
+    /// Returns the globally configured ``InstrumentProtocol``.
     ///
-    /// Defaults to a no-op ``Instrument`` if ``bootstrap(_:)`` wasn't called before.
-    public static var instrument: Instrument {
+    /// Defaults to a no-op ``InstrumentProtocol`` if ``bootstrap(_:)`` wasn't called before.
+    public static var instrument: any InstrumentProtocol {
         self.lock.withReaderLock { self._instrument }
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
 extension InstrumentationSystem {
     /// :nodoc: INTERNAL API: Do Not Use
-    public static func _findInstrument(where predicate: (Instrument) -> Bool) -> Instrument? {
+    public static func _findInstrument(where predicate: (InstrumentProtocol) -> Bool) -> InstrumentProtocol? {
         self.lock.withReaderLock {
             if let multiplex = self._instrument as? MultiplexInstrument {
                 return multiplex.firstInstrument(where: predicate)

--- a/Sources/Instrumentation/MultiplexInstrument.swift
+++ b/Sources/Instrumentation/MultiplexInstrument.swift
@@ -14,27 +14,27 @@
 
 import InstrumentationBaggage
 
-/// A pseudo-``Instrument`` that may be used to instrument using multiple other ``Instrument``s across a
+/// A pseudo-``InstrumentProtocol`` that may be used to instrument using multiple other ``InstrumentProtocol``s across a
 /// common `Baggage`.
 public struct MultiplexInstrument {
-    private var instruments: [Instrument]
+    private var instruments: [InstrumentProtocol]
 
     /// Create a ``MultiplexInstrument``.
     ///
-    /// - Parameter instruments: An array of ``Instrument``s, each of which will be used to ``Instrument/inject(_:into:using:)`` or ``Instrument/extract(_:into:using:)``
+    /// - Parameter instruments: An array of ``InstrumentProtocol``s, each of which will be used to ``InstrumentProtocol/inject(_:into:using:)`` or ``InstrumentProtocol/extract(_:into:using:)``
     /// through the same `Baggage`.
-    public init(_ instruments: [Instrument]) {
+    public init(_ instruments: [InstrumentProtocol]) {
         self.instruments = instruments
     }
 }
 
 extension MultiplexInstrument {
-    func firstInstrument(where predicate: (Instrument) -> Bool) -> Instrument? {
+    func firstInstrument(where predicate: (InstrumentProtocol) -> Bool) -> InstrumentProtocol? {
         self.instruments.first(where: predicate)
     }
 }
 
-extension MultiplexInstrument: Instrument {
+extension MultiplexInstrument: InstrumentProtocol {
     public func inject<Carrier, Inject>(_ baggage: Baggage, into carrier: inout Carrier, using injector: Inject)
         where Inject: Injector, Carrier == Inject.Carrier
     {

--- a/Sources/Instrumentation/NoOpInstrument.swift
+++ b/Sources/Instrumentation/NoOpInstrument.swift
@@ -14,8 +14,8 @@
 
 import InstrumentationBaggage
 
-/// A "no op" implementation of an ``Instrument``.
-public struct NoOpInstrument: Instrument {
+/// A "no op" implementation of an ``InstrumentProtocol``.
+public struct NoOpInstrument: InstrumentProtocol {
     public init() {}
 
     public func inject<Carrier, Inject>(_ baggage: Baggage, into carrier: inout Carrier, using injector: Inject)

--- a/Sources/Tracing/Docs.docc/InDepthGuide.md
+++ b/Sources/Tracing/Docs.docc/InDepthGuide.md
@@ -8,7 +8,7 @@ When instrumenting server applications there are typically three parties involve
 
 1. **Application developers** create server-side applications
 2. **Library/Framework developers** provide building blocks to create these applications
-3. **Instrument developers** provide tools to collect distributed metadata about your application
+3. **InstrumentProtocol developers** provide tools to collect distributed metadata about your application
 
 For applications to be instrumented correctly these three parts have to play along nicely.
 
@@ -42,7 +42,7 @@ To your main target, add a dependency on the `Instrumentation library` and the i
 
 Instead of providing each instrumented library with a specific instrument explicitly, you *bootstrap* the
 `InstrumentationSystem` which acts as a singleton that libraries/frameworks access when calling out to the configured
-`Instrument`:
+`InstrumentProtocol`:
 
 ```swift
 InstrumentationSystem.bootstrap(FancyInstrument())
@@ -63,7 +63,7 @@ This is because tracing systems may attempt to emit metrics about their status e
 
 #### Bootstrapping multiple instruments using MultiplexInstrument
 
-It is important to note that `InstrumentationSystem.bootstrap(_: Instrument)` must only be called once. In case you
+It is important to note that `InstrumentationSystem.bootstrap(_: InstrumentProtocol)` must only be called once. In case you
 want to bootstrap the system to use multiple instruments, you group them in a `MultiplexInstrument` first, which you
 then pass along to the `bootstrap` method like this:
 
@@ -188,7 +188,7 @@ Spans form hierarchies with their parent spans, and end up being visualized usin
 The above trace is achieved by starting and ending spans in all the mentioned functions, for example, like this:
 
 ```swift
-let tracer: Tracer
+let tracer: any TracerProtocol
 
 func makeDinner(context: LoggingContext) async throws -> Meal {
   tracer.withSpan(operationName: "makeDinner", context) {
@@ -225,7 +225,7 @@ func get(url: String, context: LoggingContext) {
 }
 ```
 
-On the receiving side, an HTTP server should use the following `Instrument` API to extract the HTTP headers of the given
+On the receiving side, an HTTP server should use the following `InstrumentProtocol` API to extract the HTTP headers of the given
 `HTTPRequest` into:
 
 ```swift
@@ -280,12 +280,12 @@ func get(url: String, context: LoggingContext) {
 > In the above example we used the semantic `http.method` attribute that gets exposed via the
 `TracingOpenTelemetrySupport` library.
 
-## Instrument developers: Creating an instrument
+## InstrumentProtocol developers: Creating an instrument
 
-Creating an instrument means adopting the `Instrument` protocol (or ``Tracer`` in case you develop a tracer).
-`Instrument` is part of the `Instrumentation` library & `Tracing` contains the ``Tracer`` protocol.
+Creating an instrument means adopting the `InstrumentProtocol` protocol (or ``Tracer`` in case you develop a tracer).
+`InstrumentProtocol` is part of the `Instrumentation` library & `Tracing` contains the ``Tracer`` protocol.
 
-`Instrument` has two requirements:
+`InstrumentProtocol` has two requirements:
 
 1. A method to inject values inside a `LoggingContext` into a generic carrier (e.g. HTTP headers)
 2. A method to extract values from a generic carrier (e.g. HTTP headers) and store them in a `LoggingContext`

--- a/Sources/Tracing/Docs.docc/index.md
+++ b/Sources/Tracing/Docs.docc/index.md
@@ -62,7 +62,7 @@ To your main target, add a dependency on the `Tracing` library and the instrumen
 ),
 ```
 
-Then (in an application, libraries should _never_ invoke `bootstrap`), you will want to bootstrap the specific tracer you want to use in your application. A ``Tracer`` is a type of `Instrument` and can be offered used to globally bootstrap the tracing system, like this:
+Then (in an application, libraries should _never_ invoke `bootstrap`), you will want to bootstrap the specific tracer you want to use in your application. A ``Tracer`` is a type of `InstrumentProtocol` and can be offered used to globally bootstrap the tracing system, like this:
 
 
 ```swift

--- a/Sources/Tracing/InstrumentationSystem+Tracing.swift
+++ b/Sources/Tracing/InstrumentationSystem+Tracing.swift
@@ -15,13 +15,13 @@
 @_exported import Instrumentation
 
 extension InstrumentationSystem {
+    #if swift(>=5.7.0)
     /// Returns the ``Tracer`` bootstrapped as part of the `InstrumentationSystem`.
     ///
     /// If the system was bootstrapped with a `MultiplexInstrument` this function attempts to locate the _first_
     /// tracing instrument as passed to the multiplex instrument. If none is found, a ``NoOpTracer`` is returned.
     ///
     /// - Returns: A ``Tracer`` if the system was bootstrapped with one, and ``NoOpTracer`` otherwise.
-    #if swift(>=5.7.0)
     public static var tracer: any TracerProtocol {
         let found: (any TracerProtocol)? =
             (self._findInstrument(where: { $0 is (any TracerProtocol) }) as? (any TracerProtocol))

--- a/Sources/Tracing/InstrumentationSystem+Tracing.swift
+++ b/Sources/Tracing/InstrumentationSystem+Tracing.swift
@@ -21,7 +21,23 @@ extension InstrumentationSystem {
     /// tracing instrument as passed to the multiplex instrument. If none is found, a ``NoOpTracer`` is returned.
     ///
     /// - Returns: A ``Tracer`` if the system was bootstrapped with one, and ``NoOpTracer`` otherwise.
-    public static var tracer: Tracer {
-        (self._findInstrument(where: { $0 is Tracer }) as? Tracer) ?? NoOpTracer()
+    #if swift(>=5.7.0)
+    public static var tracer: any TracerProtocol {
+        let found: (any TracerProtocol)? =
+            (self._findInstrument(where: { $0 is (any TracerProtocol) }) as? (any TracerProtocol))
+         return found ?? NoOpTracer()
+    }
+    #endif
+
+    /// Returns the ``Tracer`` bootstrapped as part of the `InstrumentationSystem`.
+    ///
+    /// If the system was bootstrapped with a `MultiplexInstrument` this function attempts to locate the _first_
+    /// tracing instrument as passed to the multiplex instrument. If none is found, a ``NoOpTracer`` is returned.
+    ///
+    /// - Returns: A ``Tracer`` if the system was bootstrapped with one, and ``NoOpTracer`` otherwise.
+    public static var legacyTracer: any LegacyTracerProtocol {
+        let found: (any LegacyTracerProtocol)? =
+            (self._findInstrument(where: { $0 is (any LegacyTracerProtocol) }) as? (any LegacyTracerProtocol))
+        return found ?? NoOpTracer()
     }
 }

--- a/Sources/Tracing/InstrumentationSystem+Tracing.swift
+++ b/Sources/Tracing/InstrumentationSystem+Tracing.swift
@@ -25,7 +25,7 @@ extension InstrumentationSystem {
     public static var tracer: any TracerProtocol {
         let found: (any TracerProtocol)? =
             (self._findInstrument(where: { $0 is (any TracerProtocol) }) as? (any TracerProtocol))
-         return found ?? NoOpTracer()
+        return found ?? NoOpTracer()
     }
     #endif
 

--- a/Sources/Tracing/NoOpTracer.swift
+++ b/Sources/Tracing/NoOpTracer.swift
@@ -28,19 +28,22 @@ public struct NoOpTracer: LegacyTracerProtocol {
                              at time: DispatchWallTime,
                              function: String,
                              file fileID: String,
-                             line: UInt) -> any SpanProtocol {
+                             line: UInt) -> any SpanProtocol
+    {
         NoOpSpan(baggage: baggage)
     }
 
     public func forceFlush() {}
 
     public func inject<Carrier, Inject>(_ baggage: Baggage, into carrier: inout Carrier, using injector: Inject)
-        where Inject: Injector, Carrier == Inject.Carrier {
+        where Inject: Injector, Carrier == Inject.Carrier
+    {
         // no-op
     }
 
     public func extract<Carrier, Extract>(_ carrier: Carrier, into baggage: inout Baggage, using extractor: Extract)
-        where Extract: Extractor, Carrier == Extract.Carrier {
+        where Extract: Extractor, Carrier == Extract.Carrier
+    {
         // no-op
     }
 
@@ -88,7 +91,6 @@ public struct NoOpTracer: LegacyTracerProtocol {
 
 #if swift(>=5.7.0)
 extension NoOpTracer: TracerProtocol {
-
     public func startSpan(
         _ operationName: String,
         baggage: Baggage,

--- a/Sources/Tracing/SpanProtocol.swift
+++ b/Sources/Tracing/SpanProtocol.swift
@@ -99,7 +99,6 @@ public protocol SpanProtocol: AnyObject, _SwiftTracingSendableSpan {
     /// - SeeAlso: `Span.end()` which automatically uses the "current" time.
     // @available(*, deprecated, message: "Use Clock based `end(at:)` instead")
     func end(at time: DispatchWallTime)
-
 }
 
 extension SpanProtocol {

--- a/Sources/Tracing/SpanProtocol.swift
+++ b/Sources/Tracing/SpanProtocol.swift
@@ -25,15 +25,6 @@ import struct Dispatch.DispatchWallTime
 ///
 /// Creating a `Span` is delegated to a ``Tracer`` and end users should never create them directly.
 ///
-/// ### Reference semantics
-/// A span always must exhibit reference semantics. Passing around a `span` must allow other pieces of code
-/// modify it safely. The span must therefore employ synchronization techniques adequate to ensure this.
-///
-/// It is allowed to implement `SpanProtocol` using a `struct` or `enum`, however the type must still exhibit reference
-/// semantics. This is useful especially for implementing efficient "no-op" or "tracing is disabled" span implementations,
-/// which can be almost empty struct instances, while their "tracing is enabled" versions should refer all state to an
-/// underlying reference type "box" which contains all the spans data.
-///
 /// - SeeAlso: For more details refer to the [OpenTelemetry Specification: Span](https://github.com/open-telemetry/opentelemetry-specification/blob/v0.7.0/specification/trace/api.md#span) which this type is compatible with.
 public protocol SpanProtocol: AnyObject, _SwiftTracingSendableSpan {
     /// The read-only `Baggage` of this `Span`, set when starting this `Span`.
@@ -121,12 +112,6 @@ extension SpanProtocol {
     }
 
     /// Adds a ``SpanLink`` between this `Span` and the given `Span`.
-    ///
-    /// ### Reference semantics
-    /// This setter `nonmutating` on purpose, a span may be implemented using a `struct`.
-    /// All state mutations performed on a struct must behave using reference semantics:
-    /// sharing a span with various pieces of code, must all be mutating the same underlying
-    /// reference semantics storage.
     ///
     /// - Parameter other: The `Span` to link to.
     /// - Parameter attributes: The ``SpanAttributes`` describing this link. Defaults to no attributes.

--- a/Sources/Tracing/SpanProtocol.swift
+++ b/Sources/Tracing/SpanProtocol.swift
@@ -88,7 +88,6 @@ public protocol SpanProtocol: AnyObject, _SwiftTracingSendableSpan {
     /// - Parameter time: The `DispatchWallTime` at which the span ended.
     ///
     /// - SeeAlso: `Span.end()` which automatically uses the "current" time.
-    // @available(*, deprecated, message: "Use Clock based `end(at:)` instead")
     func end(at time: DispatchWallTime)
 }
 

--- a/Sources/Tracing/Tracer.swift
+++ b/Sources/Tracing/Tracer.swift
@@ -16,6 +16,9 @@ import Dispatch
 @_exported import Instrumentation
 @_exported import InstrumentationBaggage
 
+/// Convenience access to static `startSpan` and `withSpan` APIs invoked on the globally bootstrapped tracer.
+///
+/// If no tracer was bootstrapped using ``InstrumentationSystem/bootstrap(_:)`` these operations are no-ops.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
 public enum Tracer {
     // namespace for short-hand operations on global bootstrapped tracer
@@ -23,10 +26,35 @@ public enum Tracer {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
 extension Tracer {
+
+    /// Start a new ``Span`` using the global bootstrapped tracer reimplementation.
+    ///
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Note: Prefer ``withSpan(_:baggage:ofKind:at:function:file:line:operation:)`` to start
+    ///   a span as it automatically takes care of ending the span, and recording errors when thrown.
+    ///   Use `startSpan` iff you need to pass the span manually to a different
+    ///   location in your source code to end it.
+    ///
+    /// - Warning: You must `end()` the span when it the measured operation has completed explicitly,
+    ///   otherwise the span object will potentially never be released nor reported.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
     static func startSpan(
         _ operationName: String,
-        baggage: Baggage,
-        ofKind kind: SpanKind,
+        baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
+        ofKind kind: SpanKind = .internal,
         at time: DispatchWallTime = .now(),
         function: String = #function,
         file fileID: String = #fileID,
@@ -37,9 +65,6 @@ extension Tracer {
         #if swift(>=5.7.0)
         InstrumentationSystem.tracer.startSpan(
             operationName,
-            baggage: baggage,
-            ofKind: kind,
-            at: time,
             function: function,
             file: fileID,
             line: line
@@ -57,42 +82,32 @@ extension Tracer {
         #endif
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
-    static func startSpan(
-        _ operationName: String,
-        ofKind kind: SpanKind,
-        function: String = #function,
-        file fileID: String = #fileID,
-        line: UInt = #line
-    ) -> any SpanProtocol {
-        // Effectively these end up calling the same method, however
-        // we try to not use the deprecated methods ourselves anyway
-        #if swift(>=5.7.0)
-        InstrumentationSystem.tracer.startSpan(
-            operationName,
-            baggage: .current ?? .topLevel,
-            ofKind: kind,
-            at: .now(),
-            function: function,
-            file: fileID,
-            line: line
-        )
-        #else
-        InstrumentationSystem.legacyTracer.startAnySpan(
-            operationName,
-            baggage: .current ?? .topLevel,
-            ofKind: kind,
-            at: .now(),
-            function: function,
-            file: fileID,
-            line: line
-        )
-        #endif
-    }
-
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    /// Start a new ``Span`` and automatically end when the `operation` completes,
+    /// including recording the `error` in case the operation throws.
+    ///
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Warning: You MUST NOT ``SpanProtocol/end()`` the span explicitly, because at the end of the `withSpan`
+    ///   operation closure returning the span will be closed automatically.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
+    ///   - operation: The operation that this span should be measuring
+    /// - Returns: the value returned by `operation`
+    /// - Throws: the error the `operation` has thrown (if any)
     public static func withSpan<T>(
         _ operationName: String,
+        baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
         function: String = #function,
         file fileID: String = #fileID,
@@ -122,12 +137,36 @@ extension Tracer {
         #endif
     }
 
-    #if swift(>=5.7.0)
+    /// Start a new ``Span`` and automatically end when the `operation` completes,
+    /// including recording the `error` in case the operation throws.
+    ///
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Warning: You MUST NOT ``SpanProtocol/end()`` the span explicitly, because at the end of the `withSpan`
+    ///   operation closure returning the span will be closed automatically.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
+    ///   - operation: The operation that this span should be measuring
+    /// - Returns: the value returned by `operation`
+    /// - Throws: the error the `operation` has thrown (if any)
     @_unsafeInheritExecutor
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public static func withSpan<T>(
         _ operationName: String,
+        baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
+        at time: DispatchWallTime = .now(),
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
@@ -135,7 +174,9 @@ extension Tracer {
     ) async rethrows -> T {
         try await InstrumentationSystem.tracer.withAnySpan(
             operationName,
+            baggage: baggage(),
             ofKind: kind,
+            at: time,
             function: function,
             file: fileID,
             line: line
@@ -143,25 +184,4 @@ extension Tracer {
             try await operation(anySpan)
         }
     }
-    #else
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public static func withSpan<T>(
-        _ operationName: String,
-        ofKind kind: SpanKind = .internal,
-        function: String = #function,
-        file fileID: String = #fileID,
-        line: UInt = #line,
-        _ operation: (any SpanProtocol) async throws -> T
-    ) async rethrows -> T {
-        try await InstrumentationSystem.legacyTracer.withAnySpan(
-            operationName,
-            ofKind: kind,
-            function: function,
-            file: fileID,
-            line: line
-        ) { anySpan in
-            try await operation(anySpan)
-        }
-    }
-    #endif
 }

--- a/Sources/Tracing/Tracer.swift
+++ b/Sources/Tracing/Tracer.swift
@@ -16,309 +16,148 @@ import Dispatch
 @_exported import Instrumentation
 @_exported import InstrumentationBaggage
 
-/// An `Instrument` with added functionality for distributed tracing. It uses the span-based tracing model and is
-/// based on the OpenTracing/OpenTelemetry spec.
-public protocol Tracer: Instrument {
-    /// Start a new ``Span`` with the given `Baggage` at a given time.
-    ///
-    /// - Note: Prefer to use `withSpan` to start a span as it automatically takes care of ending the span,
-    /// and recording errors when thrown. Use `startSpan` iff you need to pass the span manually to a different
-    /// location in your source code to end it.
-    ///
-    /// - Parameters:
-    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
-    ///   - kind: The ``SpanKind`` of the new ``Span``.
-    ///   - time: The time at which to start the new ``Span``.
-    ///   - function: The function name in which the span was started
-    ///   - fileID: The `fileID` where the span was started.
-    ///   - line: The file line where the span was started.
-    func startSpan(
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+public enum Tracer {
+    // namespace for short-hand operations on global bootstrapped tracer
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+extension Tracer {
+    static func startSpan(
         _ operationName: String,
         baggage: Baggage,
         ofKind kind: SpanKind,
-        at time: DispatchWallTime,
-        function: String,
-        file fileID: String,
-        line: UInt
-    ) -> Span
-
-    /// Export all ended spans to the configured backend that have not yet been exported.
-    ///
-    /// This function should only be called in cases where it is absolutely necessary,
-    /// such as when using some FaaS providers that may suspend the process after an invocation, but before the backend exports the completed spans.
-    ///
-    /// This function should not block indefinitely, implementations should offer a configurable timeout for flush operations.
-    func forceFlush()
-}
-
-extension Tracer {
-    #if swift(>=5.3.0)
-    /// Start a new ``Span`` with the given `Baggage` starting "now".
-    ///
-    /// - Parameters:
-    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-    ///   - baggage: Baggage potentially containing trace identifiers of a parent ``Span``.
-    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
-    ///   - function: The function name in which the span was started.
-    ///   - fileID: The `fileID` where the span was started.
-    ///   - line: The file line where the span was started.
-    public func startSpan(
-        _ operationName: String,
-        baggage: Baggage,
-        ofKind kind: SpanKind = .internal,
+        at time: DispatchWallTime = .now(),
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line
-    ) -> Span {
-        self.startSpan(
+    ) -> any SpanProtocol {
+        // Effectively these end up calling the same method, however
+        // we try to not use the deprecated methods ourselves anyway
+        #if swift(>=5.7.0)
+        InstrumentationSystem.tracer.startSpan(
             operationName,
             baggage: baggage,
+            ofKind: kind,
+            at: time,
+            function: function,
+            file: fileID,
+            line: line
+        )
+        #else
+        InstrumentationSystem.legacyTracer.startAnySpan(
+        operationName,
+        baggage: baggage,
+        ofKind: kind,
+        at: time,
+        function: function,
+        file: fileID,
+        line: line
+        )
+        #endif
+    }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+    static func startSpan(
+        _ operationName: String,
+        ofKind kind: SpanKind,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line
+    ) -> any SpanProtocol {
+        // Effectively these end up calling the same method, however
+        // we try to not use the deprecated methods ourselves anyway
+        #if swift(>=5.7.0)
+        InstrumentationSystem.tracer.startSpan(
+            operationName,
+            baggage: .current ?? .topLevel,
             ofKind: kind,
             at: .now(),
             function: function,
             file: fileID,
             line: line
         )
-    }
-    #else
-    /// Start a new ``Span`` with the given `Baggage` starting "now".
-    ///
-    /// - Parameters:
-    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-    ///   - baggage: Baggage potentially containing trace identifiers of a parent ``Span``.
-    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
-    ///   - function: The function name in which the span was started.
-    ///   - file: The `file` where the span was started.
-    ///   - line: The file line where the span was started.
-    public func startSpan(
-        _ operationName: String,
-        baggage: Baggage,
-        ofKind kind: SpanKind = .internal,
-        function: String = #function,
-        file: String = #file,
-        line: UInt = #line
-    ) -> Span {
-        self.startSpan(
+        #else
+        InstrumentationSystem.legacyTracer.startAnySpan(
             operationName,
-            baggage: baggage,
+            baggage: .current ?? .topLevel,
             ofKind: kind,
             at: .now(),
             function: function,
-            file: file,
+            file: fileID,
             line: line
         )
+        #endif
     }
-    #endif
-}
 
-// ==== ----------------------------------------------------------------------------------------------------------------
-// MARK: Starting spans: `withSpan`
-
-extension Tracer {
-    #if swift(>=5.3.0)
-    /// Execute a specific task within a newly created ``Span``.
-    ///
-    /// DO NOT `end()` the passed in span manually. It will be ended automatically when the `operation` returns.
-    ///
-    /// - Parameters:
-    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-    ///   - baggage: Baggage potentially containing trace identifiers of a parent ``Span``.
-    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
-    ///   - operation: operation to wrap in a span start/end and execute immediately
-    ///   - function: The function name in which the span was started.
-    ///   - fileID: The `fileID` where the span was started.
-    ///   - line: The file line where the span was started.
-    /// - Returns: the value returned by `operation`
-    /// - Throws: the error the `operation` has thrown (if any)
-    public func withSpan<T>(
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    public static func withSpan<T>(
         _ operationName: String,
-        baggage: Baggage,
         ofKind kind: SpanKind = .internal,
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
-        _ operation: (Span) throws -> T
+        _ operation: (any SpanProtocol) throws -> T
     ) rethrows -> T {
-        let span = self.startSpan(
+        #if swift(>=5.7.0)
+        try InstrumentationSystem.legacyTracer.withAnySpan(
             operationName,
-            baggage: baggage,
             ofKind: kind,
-            at: .now(),
             function: function,
             file: fileID,
-            line: line
-        )
-        defer { span.end() }
-        do {
-            return try operation(span)
-        } catch {
-            span.recordError(error)
-            throw error // rethrow
+            line: line) { anySpan in
+            try operation(anySpan)
+        }
+        #else
+        try InstrumentationSystem.legacyTracer.withAnySpan(
+            operationName,
+            ofKind: kind,
+            function: function,
+            file: fileID,
+            line: line) { anySpan in
+            try operation(anySpan)
+        }
+        #endif
+    }
+
+    #if swift(>=5.7.0)
+    @_unsafeInheritExecutor
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    public static func withSpan<T>(
+        _ operationName: String,
+        ofKind kind: SpanKind = .internal,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        _ operation: (any SpanProtocol) async throws -> T
+    ) async rethrows -> T {
+        try await InstrumentationSystem.tracer.withAnySpan(
+            operationName,
+            ofKind: kind,
+            function: function,
+            file: fileID,
+            line: line) { anySpan in
+            try await operation(anySpan)
         }
     }
     #else
-    /// Execute a specific task within a newly created ``Span``.
-    ///
-    /// DO NOT `end()` the passed in span manually. It will be ended automatically when the `operation` returns.
-    ///
-    /// - Parameters:
-    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-    ///   - baggage: Baggage potentially containing trace identifiers of a parent ``Span``.
-    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
-    ///   - operation: operation to wrap in a span start/end and execute immediately
-    ///   - function: The function name in which the span was started.
-    ///   - file: The `#file` where the span was started.
-    ///   - line: The file line where the span was started.
-    /// - Returns: the value returned by `operation`
-    /// - Throws: the error the `operation` has thrown (if any)
-    public func withSpan<T>(
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    public static func withSpan<T>(
         _ operationName: String,
-        baggage: Baggage,
         ofKind kind: SpanKind = .internal,
         function: String = #function,
-        file: String = #file,
+        file fileID: String = #fileID,
         line: UInt = #line,
-        _ operation: (Span) throws -> T
-    ) rethrows -> T {
-        let span = self.startSpan(
+        _ operation: (any SpanProtocol) async throws -> T
+    ) async rethrows -> T {
+        try await InstrumentationSystem.legacyTracer.withAnySpan(
             operationName,
-            baggage: baggage,
             ofKind: kind,
-            at: .now(),
             function: function,
-            file: file,
-            line: line
-        )
-        defer { span.end() }
-        do {
-            return try operation(span)
-        } catch {
-            span.recordError(error)
-            throw error // rethrow
+            file: fileID,
+            line: line) { anySpan in
+            try await operation(anySpan)
         }
     }
     #endif
 }
-
-// ==== ----------------------------------------------------------------------------------------------------------------
-// MARK: Starting spans: Task-local Baggage propagation
-
-#if swift(>=5.5) && canImport(_Concurrency)
-@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-extension Tracer {
-    /// Execute the given operation within a newly created ``Span``,
-    /// started as a child of the currently stored task local `Baggage.current` or as a root span if `nil`.
-    ///
-    /// DO NOT `end()` the passed in span manually. It will be ended automatically when the `operation` returns.
-    ///
-    /// - Parameters:
-    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
-    ///   - operation: operation to wrap in a span start/end and execute immediately
-    ///   - function: The function name in which the span was started.
-    ///   - fileID: The `fileID` where the span was started.
-    ///   - line: The file line where the span was started.
-    /// - Returns: the value returned by `operation`
-    /// - Throws: the error the `operation` has thrown (if any)
-    public func withSpan<T>(
-        _ operationName: String,
-        ofKind kind: SpanKind = .internal,
-        function: String = #function,
-        file fileID: String = #fileID,
-        line: UInt = #line,
-        _ operation: (Span) throws -> T
-    ) rethrows -> T {
-        try self.withSpan(
-            operationName,
-            baggage: .current ?? .topLevel,
-            ofKind: kind,
-            function: function,
-            file: fileID,
-            line: line
-        ) { span in
-            try Baggage.$current.withValue(span.baggage) {
-                try operation(span)
-            }
-        }
-    }
-
-    /// Execute the given async operation within a newly created ``Span``,
-    /// started as a child of the currently stored task local `Baggage.current` or as a root span if `nil`.
-    ///
-    /// DO NOT `end()` the passed in span manually. It will be ended automatically when the `operation` returns.
-    ///
-    /// - Parameters:
-    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
-    ///   - operation: operation to wrap in a span start/end and execute immediately
-    ///   - function: The function name in which the span was started.
-    ///   - fileID: The `fileID` where the span was started.
-    ///   - line: The file line where the span was started.
-    /// - Returns: the value returned by `operation`
-    /// - Throws: the error the `operation` has thrown (if any)
-    public func withSpan<T>(
-        _ operationName: String,
-        ofKind kind: SpanKind = .internal,
-        function: String = #function,
-        file fileID: String = #fileID,
-        line: UInt = #line,
-        _ operation: (Span) async throws -> T
-    ) async rethrows -> T {
-        let span = self.startSpan(
-            operationName,
-            baggage: .current ?? .topLevel,
-            ofKind: kind,
-            function: function,
-            file: fileID,
-            line: line
-        )
-        defer { span.end() }
-        do {
-            return try await Baggage.$current.withValue(span.baggage) {
-                try await operation(span)
-            }
-        } catch {
-            span.recordError(error)
-            throw error // rethrow
-        }
-    }
-
-    /// Execute the given async operation within a newly created `Span`,
-    /// started as a child of the passed in `Baggage` or as a root span if `nil`.
-    ///
-    /// DO NOT `end()` the passed in span manually. It will be ended automatically when the `operation` returns.
-    ///
-    /// - Parameters:
-    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-    ///   - baggage: The baggage to be used for the newly created span. It may be obtained by the user manually from the `Baggage.current`,
-    //               task local and modified before passing into this function. The baggage will be made the current task-local baggage for the duration of the `operation`.
-    ///   - kind: The `SpanKind` of the `Span` to be created. Defaults to `.internal`.
-    ///   - operation: operation to wrap in a span start/end and execute immediately
-    ///   - function: The function name in which the span was started.
-    ///   - fileID: The `fileID` where the span was started.
-    ///   - line: The file line where the span was started.
-    /// - Returns: the value returned by `operation`
-    /// - Throws: the error the `operation` has thrown (if any)
-    public func withSpan<T>(
-        _ operationName: String,
-        baggage: Baggage,
-        ofKind kind: SpanKind = .internal,
-        function: String = #function,
-        file fileID: String = #fileID,
-        line: UInt = #line,
-        _ operation: (Span) async throws -> T
-    ) async rethrows -> T {
-        let span = self.startSpan(operationName, baggage: baggage, ofKind: kind, function: function, file: fileID, line: line)
-        defer { span.end() }
-        do {
-            return try await Baggage.$current.withValue(span.baggage) {
-                try await operation(span)
-            }
-        } catch {
-            span.recordError(error)
-            throw error // rethrow
-        }
-    }
-}
-#endif

--- a/Sources/Tracing/Tracer.swift
+++ b/Sources/Tracing/Tracer.swift
@@ -46,13 +46,13 @@ extension Tracer {
         )
         #else
         InstrumentationSystem.legacyTracer.startAnySpan(
-        operationName,
-        baggage: baggage,
-        ofKind: kind,
-        at: time,
-        function: function,
-        file: fileID,
-        line: line
+            operationName,
+            baggage: baggage,
+            ofKind: kind,
+            at: time,
+            function: function,
+            file: fileID,
+            line: line
         )
         #endif
     }
@@ -105,7 +105,8 @@ extension Tracer {
             ofKind: kind,
             function: function,
             file: fileID,
-            line: line) { anySpan in
+            line: line
+        ) { anySpan in
             try operation(anySpan)
         }
         #else
@@ -114,7 +115,8 @@ extension Tracer {
             ofKind: kind,
             function: function,
             file: fileID,
-            line: line) { anySpan in
+            line: line
+        ) { anySpan in
             try operation(anySpan)
         }
         #endif
@@ -136,7 +138,8 @@ extension Tracer {
             ofKind: kind,
             function: function,
             file: fileID,
-            line: line) { anySpan in
+            line: line
+        ) { anySpan in
             try await operation(anySpan)
         }
     }
@@ -155,7 +158,8 @@ extension Tracer {
             ofKind: kind,
             function: function,
             file: fileID,
-            line: line) { anySpan in
+            line: line
+        ) { anySpan in
             try await operation(anySpan)
         }
     }

--- a/Sources/Tracing/TracerProtocol+Legacy.swift
+++ b/Sources/Tracing/TracerProtocol+Legacy.swift
@@ -1,0 +1,203 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Tracing open source project
+//
+// Copyright (c) 2020-2022 Apple Inc. and the Swift Distributed Tracing project
+// authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+@_exported import Instrumentation
+@_exported import InstrumentationBaggage
+
+// @available(*, deprecated, message: "Use 'TracerProtocol' instead")
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+public protocol LegacyTracerProtocol: InstrumentProtocol {
+
+    // @available(*, deprecated, message: "Use 'TracerProtocol/startSpan' instead")
+    func startAnySpan(
+        _ operationName: String,
+        baggage: Baggage,
+        ofKind kind: SpanKind,
+        at time: DispatchWallTime,
+        function: String,
+        file fileID: String,
+        line: UInt
+    ) -> any SpanProtocol
+
+    /// Export all ended spans to the configured backend that have not yet been exported.
+    ///
+    /// This function should only be called in cases where it is absolutely necessary,
+    /// such as when using some FaaS providers that may suspend the process after an invocation, but before the backend exports the completed spans.
+    ///
+    /// This function should not block indefinitely, implementations should offer a configurable timeout for flush operations.
+    func forceFlush()
+
+}
+
+// ==== ------------------------------------------------------------------
+// MARK: Legacy implementations for Swift 5.7
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+extension LegacyTracerProtocol {
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+    public func startAnySpan(
+        _ operationName: String,
+        baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
+        ofKind kind: SpanKind = .internal,
+        at time: DispatchWallTime = .now(),
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line
+    ) -> any SpanProtocol {
+        self.startAnySpan(
+            operationName,
+            baggage: baggage(),
+            ofKind: kind,
+            at: time,
+            function: function,
+            file: fileID,
+            line: line)
+    }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+    public func withAnySpan<T>(
+        _ operationName: String,
+        baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
+        ofKind kind: SpanKind = .internal,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        _ operation: (any SpanProtocol) throws -> T
+    ) rethrows -> T {
+        let span = self.startAnySpan(operationName, baggage: baggage(), ofKind: kind, at: .now(), function: function, file: fileID, line: line)
+        defer { span.end() }
+        do {
+            return try Baggage.$current.withValue(span.baggage) {
+                try operation(span)
+            }
+        } catch {
+            span.recordError(error)
+            throw error // rethrow
+        }
+    }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    public func withAnySpan<T>(
+        _ operationName: String,
+        baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
+        ofKind kind: SpanKind = .internal,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        _ operation: (any SpanProtocol) async throws -> T
+    ) async rethrows -> T {
+        let span = self.startAnySpan(operationName, baggage: baggage(), ofKind: kind, at: .now(), function: function, file: fileID, line: line)
+        defer { span.end() }
+        do {
+            return try await Baggage.$current.withValue(span.baggage) {
+                try await operation(span)
+            }
+        } catch {
+            span.recordError(error)
+            throw error // rethrow
+        }
+    }
+
+}
+
+#if swift(>=5.7.0)
+extension TracerProtocol {
+    public func startAnySpan(
+        _ operationName: String,
+        baggage: Baggage,
+        ofKind kind: SpanKind,
+        at time: DispatchWallTime,
+        function: String,
+        file fileID: String,
+        line: UInt
+    ) -> any SpanProtocol {
+        self.startSpan(
+            operationName,
+            baggage: baggage,
+            ofKind: kind,
+            at: time,
+            function: function,
+            file: fileID,
+            line: line
+        )
+    }
+
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    // @available(*, deprecated, message: "Use 'TracerProtocol/withSpan' instead")
+    public func withAnySpan<T>(
+        _ operationName: String,
+        ofKind kind: SpanKind,
+        function: String,
+        file fileID: String,
+        line: UInt,
+        _ operation: (any SpanProtocol) throws -> T
+    ) rethrows -> T {
+        try self.withSpan(
+            operationName,
+            ofKind: kind,
+            function: function,
+            file: fileID,
+            line: line) { span in
+            try operation(span)
+        }
+    }
+
+    #if swift(>=5.7.0)
+    @_unsafeInheritExecutor
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    // @available(*, deprecated, message: "Use 'TracerProtocol/withSpan' instead")
+    public func withAnySpan<T>(
+        _ operationName: String,
+        ofKind kind: SpanKind,
+        function: String,
+        file fileID: String,
+        line: UInt,
+        _ operation: (any SpanProtocol) async throws -> T
+    ) async rethrows -> T {
+        try await self.withSpan(
+            operationName,
+            ofKind: kind,
+            function: function,
+            file: fileID,
+            line: line) { span in
+            try await operation(span)
+        }
+    }
+    #else
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    // @available(*, deprecated, message: "Use 'TracerProtocol/withSpan' instead")
+    public func withAnySpan<T>(
+        _ operationName: String,
+        ofKind kind: SpanKind,
+        function: String,
+        file fileID: String,
+        line: UInt,
+        _ operation: (any SpanProtocol) async throws -> T
+    ) async rethrows -> T {
+        try await self.withSpan(
+            operationName,
+            ofKind: kind,
+            function: function,
+            file: fileID,
+            line: line) { span in
+            try await operation(span)
+        }
+    }
+    #endif
+
+}
+#endif

--- a/Sources/Tracing/TracerProtocol+Legacy.swift
+++ b/Sources/Tracing/TracerProtocol+Legacy.swift
@@ -19,7 +19,6 @@ import Dispatch
 // @available(*, deprecated, message: "Use 'TracerProtocol' instead")
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
 public protocol LegacyTracerProtocol: InstrumentProtocol {
-
     // @available(*, deprecated, message: "Use 'TracerProtocol/startSpan' instead")
     func startAnySpan(
         _ operationName: String,
@@ -38,7 +37,6 @@ public protocol LegacyTracerProtocol: InstrumentProtocol {
     ///
     /// This function should not block indefinitely, implementations should offer a configurable timeout for flush operations.
     func forceFlush()
-
 }
 
 // ==== ------------------------------------------------------------------
@@ -46,7 +44,6 @@ public protocol LegacyTracerProtocol: InstrumentProtocol {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
 extension LegacyTracerProtocol {
-
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
     public func startAnySpan(
         _ operationName: String,
@@ -64,7 +61,8 @@ extension LegacyTracerProtocol {
             at: time,
             function: function,
             file: fileID,
-            line: line)
+            line: line
+        )
     }
 
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
@@ -110,7 +108,6 @@ extension LegacyTracerProtocol {
             throw error // rethrow
         }
     }
-
 }
 
 #if swift(>=5.7.0)
@@ -135,7 +132,6 @@ extension TracerProtocol {
         )
     }
 
-
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     // @available(*, deprecated, message: "Use 'TracerProtocol/withSpan' instead")
     public func withAnySpan<T>(
@@ -151,7 +147,8 @@ extension TracerProtocol {
             ofKind: kind,
             function: function,
             file: fileID,
-            line: line) { span in
+            line: line
+        ) { span in
             try operation(span)
         }
     }
@@ -173,7 +170,8 @@ extension TracerProtocol {
             ofKind: kind,
             function: function,
             file: fileID,
-            line: line) { span in
+            line: line
+        ) { span in
             try await operation(span)
         }
     }
@@ -193,11 +191,11 @@ extension TracerProtocol {
             ofKind: kind,
             function: function,
             file: fileID,
-            line: line) { span in
+            line: line
+        ) { span in
             try await operation(span)
         }
     }
     #endif
-
 }
 #endif

--- a/Sources/Tracing/TracerProtocol+Legacy.swift
+++ b/Sources/Tracing/TracerProtocol+Legacy.swift
@@ -16,13 +16,40 @@ import Dispatch
 @_exported import Instrumentation
 @_exported import InstrumentationBaggage
 
-// @available(*, deprecated, message: "Use 'TracerProtocol' instead")
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
 public protocol LegacyTracerProtocol: InstrumentProtocol {
-    // @available(*, deprecated, message: "Use 'TracerProtocol/startSpan' instead")
+    /// Start a new span returning an existential ``SpanProtocol`` reference.
+    ///
+    /// This API will be deprecated as soon as Swift 5.9 is released, and the Swift 5.7 requiring `TracerProtocol`
+    /// is recommended instead.
+    ///
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Note: Legacy API, prefer using ``startSpan(_:baggage:ofKind:at:
+    ///
+    /// - Note: Prefer ``withSpan(_:baggage:ofKind:at:function:file:line:operation:)`` to start
+    ///   a span as it automatically takes care of ending the span, and recording errors when thrown.
+    ///   Use `startSpan` iff you need to pass the span manually to a different
+    ///   location in your source code to end it.
+    ///
+    /// - Warning: You must `end()` the span when it the measured operation has completed explicitly,
+    ///   otherwise the span object will potentially never be released nor reported.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
     func startAnySpan(
         _ operationName: String,
-        baggage: Baggage,
+        baggage: @autoclosure () -> Baggage,
         ofKind kind: SpanKind,
         at time: DispatchWallTime,
         function: String,
@@ -44,7 +71,35 @@ public protocol LegacyTracerProtocol: InstrumentProtocol {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
 extension LegacyTracerProtocol {
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+    /// Start a new span returning an existential ``SpanProtocol`` reference.
+    ///
+    /// This API will be deprecated as soon as Swift 5.9 is released, and the Swift 5.7 requiring `TracerProtocol`
+    /// is recommended instead.
+    ///
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Note: Legacy API, prefer using ``startSpan(_:baggage:ofKind:at:
+    ///
+    /// - Note: Prefer ``withSpan(_:baggage:ofKind:at:function:file:line:operation:)`` to start
+    ///   a span as it automatically takes care of ending the span, and recording errors when thrown.
+    ///   Use `startSpan` iff you need to pass the span manually to a different
+    ///   location in your source code to end it.
+    ///
+    /// - Warning: You must `end()` the span when it the measured operation has completed explicitly,
+    ///   otherwise the span object will potentially never be released nor reported.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
     public func startAnySpan(
         _ operationName: String,
         baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
@@ -65,17 +120,50 @@ extension LegacyTracerProtocol {
         )
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+    /// Start a new ``SpanProtocol`` and automatically end when the `operation` completes,
+    /// including recording the `error` in case the operation throws.
+    ///
+    /// This API will be deprecated as soon as Swift 5.9 is released, and the Swift 5.7 requiring `TracerProtocol`
+    /// is recommended instead.
+    ///
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Note: Legacy API, prefer using ``startSpan(_:baggage:ofKind:at:
+    ///
+    /// - Note: Prefer ``withSpan(_:baggage:ofKind:at:function:file:line:operation:)`` to start
+    ///   a span as it automatically takes care of ending the span, and recording errors when thrown.
+    ///   Use `startSpan` iff you need to pass the span manually to a different
+    ///   location in your source code to end it.
+    ///
+    /// - Warning: You must `end()` the span when it the measured operation has completed explicitly,
+    ///   otherwise the span object will potentially never be released nor reported.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
+    ///   - operation: The operation that this span should be measuring
+    /// - Returns: the value returned by `operation`
+    /// - Throws: the error the `operation` has thrown (if any)
     public func withAnySpan<T>(
         _ operationName: String,
         baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
+        at time: DispatchWallTime = .now(),
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
         _ operation: (any SpanProtocol) throws -> T
     ) rethrows -> T {
-        let span = self.startAnySpan(operationName, baggage: baggage(), ofKind: kind, at: .now(), function: function, file: fileID, line: line)
+        let span = self.startAnySpan(operationName, baggage: baggage(), ofKind: kind, at: time, function: function, file: fileID, line: line)
         defer { span.end() }
         do {
             return try Baggage.$current.withValue(span.baggage) {
@@ -87,21 +175,57 @@ extension LegacyTracerProtocol {
         }
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    /// Start a new ``SpanProtocol`` and automatically end when the `operation` completes,
+    /// including recording the `error` in case the operation throws.
+    ///
+    /// This API will be deprecated as soon as Swift 5.9 is released, and the Swift 5.7 requiring `TracerProtocol`
+    /// is recommended instead.
+    ///
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Note: Legacy API, prefer using ``startSpan(_:baggage:ofKind:at:
+    ///
+    /// - Note: Prefer ``withSpan(_:baggage:ofKind:at:function:file:line:operation:)`` to start
+    ///   a span as it automatically takes care of ending the span, and recording errors when thrown.
+    ///   Use `startSpan` iff you need to pass the span manually to a different
+    ///   location in your source code to end it.
+    ///
+    /// - Warning: You must `end()` the span when it the measured operation has completed explicitly,
+    ///   otherwise the span object will potentially never be released nor reported.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
+    ///   - operation: The operation that this span should be measuring
+    /// - Returns: the value returned by `operation`
+    /// - Throws: the error the `operation` has thrown (if any)
     public func withAnySpan<T>(
         _ operationName: String,
         baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
+        at time: DispatchWallTime = .now(),
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
         _ operation: (any SpanProtocol) async throws -> T
     ) async rethrows -> T {
-        let span = self.startAnySpan(operationName, baggage: baggage(), ofKind: kind, at: .now(), function: function, file: fileID, line: line)
+        print("HI: \(Self.self) \(#function) @ \(#file):\(#line)")
+
+        let span = self.startAnySpan(operationName, baggage: baggage(), ofKind: kind, at: time, function: function, file: fileID, line: line)
         defer { span.end() }
         do {
             return try await Baggage.$current.withValue(span.baggage) {
-                try await operation(span)
+                print("OP: \(#function)")
+                return try await operation(span)
             }
         } catch {
             span.recordError(error)
@@ -111,19 +235,52 @@ extension LegacyTracerProtocol {
 }
 
 #if swift(>=5.7.0)
+// Provide compatibility shims of the `...AnySpan` APIs to the 5.7 requiring `TracerProtocol`.
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension TracerProtocol {
+
+    /// Start a new span returning an existential ``SpanProtocol`` reference.
+    ///
+    /// This API will be deprecated as soon as Swift 5.9 is released, and the Swift 5.7 requiring `TracerProtocol`
+    /// is recommended instead.
+    ///
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Note: Legacy API, prefer using ``startSpan(_:baggage:ofKind:at:
+    ///
+    /// - Note: Prefer ``withSpan(_:baggage:ofKind:at:function:file:line:operation:)`` to start
+    ///   a span as it automatically takes care of ending the span, and recording errors when thrown.
+    ///   Use `startSpan` iff you need to pass the span manually to a different
+    ///   location in your source code to end it.
+    ///
+    /// - Warning: You must `end()` the span when it the measured operation has completed explicitly,
+    ///   otherwise the span object will potentially never be released nor reported.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
     public func startAnySpan(
         _ operationName: String,
-        baggage: Baggage,
-        ofKind kind: SpanKind,
-        at time: DispatchWallTime,
-        function: String,
-        file fileID: String,
-        line: UInt
+        baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
+        ofKind kind: SpanKind = .internal,
+        at time: DispatchWallTime = .now(),
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line
     ) -> any SpanProtocol {
         self.startSpan(
             operationName,
-            baggage: baggage,
+            baggage: baggage(),
             ofKind: kind,
             at: time,
             function: function,
@@ -132,19 +289,55 @@ extension TracerProtocol {
         )
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    // @available(*, deprecated, message: "Use 'TracerProtocol/withSpan' instead")
+
+    /// Start a new ``SpanProtocol`` and automatically end when the `operation` completes,
+    /// including recording the `error` in case the operation throws.
+    ///
+    /// This API will be deprecated as soon as Swift 5.9 is released, and the Swift 5.7 requiring `TracerProtocol`
+    /// is recommended instead.
+    ///
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Note: Legacy API, prefer using ``startSpan(_:baggage:ofKind:at:
+    ///
+    /// - Note: Prefer ``withSpan(_:baggage:ofKind:at:function:file:line:operation:)`` to start
+    ///   a span as it automatically takes care of ending the span, and recording errors when thrown.
+    ///   Use `startSpan` iff you need to pass the span manually to a different
+    ///   location in your source code to end it.
+    ///
+    /// - Warning: You must `end()` the span when it the measured operation has completed explicitly,
+    ///   otherwise the span object will potentially never be released nor reported.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
+    ///   - operation: The operation that this span should be measuring
+    /// - Returns: the value returned by `operation`
+    /// - Throws: the error the `operation` has thrown (if any)
     public func withAnySpan<T>(
         _ operationName: String,
-        ofKind kind: SpanKind,
-        function: String,
-        file fileID: String,
-        line: UInt,
+        baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
+        ofKind kind: SpanKind = .internal,
+        at time: DispatchWallTime = .now(),
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
         _ operation: (any SpanProtocol) throws -> T
     ) rethrows -> T {
         try self.withSpan(
             operationName,
+            baggage: baggage(),
             ofKind: kind,
+            at: time,
             function: function,
             file: fileID,
             line: line
@@ -153,21 +346,56 @@ extension TracerProtocol {
         }
     }
 
-    #if swift(>=5.7.0)
+
+    /// Start a new ``SpanProtocol`` and automatically end when the `operation` completes,
+    /// including recording the `error` in case the operation throws.
+    ///
+    /// This API will be deprecated as soon as Swift 5.9 is released, and the Swift 5.7 requiring `TracerProtocol`
+    /// is recommended instead.
+    ///
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Note: Legacy API, prefer using ``startSpan(_:baggage:ofKind:at:
+    ///
+    /// - Note: Prefer ``withSpan(_:baggage:ofKind:at:function:file:line:operation:)`` to start
+    ///   a span as it automatically takes care of ending the span, and recording errors when thrown.
+    ///   Use `startSpan` iff you need to pass the span manually to a different
+    ///   location in your source code to end it.
+    ///
+    /// - Warning: You must `end()` the span when it the measured operation has completed explicitly,
+    ///   otherwise the span object will potentially never be released nor reported.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
+    ///   - operation: The operation that this span should be measuring
+    /// - Returns: the value returned by `operation`
+    /// - Throws: the error the `operation` has thrown (if any)
     @_unsafeInheritExecutor
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    // @available(*, deprecated, message: "Use 'TracerProtocol/withSpan' instead")
     public func withAnySpan<T>(
         _ operationName: String,
-        ofKind kind: SpanKind,
-        function: String,
-        file fileID: String,
-        line: UInt,
+        baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
+        ofKind kind: SpanKind = .internal,
+        at time: DispatchWallTime = .now(),
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
         _ operation: (any SpanProtocol) async throws -> T
     ) async rethrows -> T {
         try await self.withSpan(
             operationName,
+            baggage: baggage(),
             ofKind: kind,
+            at: time,
             function: function,
             file: fileID,
             line: line
@@ -175,27 +403,5 @@ extension TracerProtocol {
             try await operation(span)
         }
     }
-    #else
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    // @available(*, deprecated, message: "Use 'TracerProtocol/withSpan' instead")
-    public func withAnySpan<T>(
-        _ operationName: String,
-        ofKind kind: SpanKind,
-        function: String,
-        file fileID: String,
-        line: UInt,
-        _ operation: (any SpanProtocol) async throws -> T
-    ) async rethrows -> T {
-        try await self.withSpan(
-            operationName,
-            ofKind: kind,
-            function: function,
-            file: fileID,
-            line: line
-        ) { span in
-            try await operation(span)
-        }
-    }
-    #endif
 }
 #endif

--- a/Sources/Tracing/TracerProtocol.swift
+++ b/Sources/Tracing/TracerProtocol.swift
@@ -1,0 +1,317 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Tracing open source project
+//
+// Copyright (c) 2020-2022 Apple Inc. and the Swift Distributed Tracing project
+// authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+@_exported import Instrumentation
+@_exported import InstrumentationBaggage
+
+// ==== -----------------------------------------------------------------------
+// MARK: Tracer protocol
+
+#if swift(>=5.7.0)
+/// An `InstrumentProtocol` with added functionality for distributed tracing. It uses the span-based tracing model and is
+/// based on the OpenTracing/OpenTelemetry spec.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+public protocol TracerProtocol: LegacyTracerProtocol {
+    associatedtype Span: SpanProtocol
+
+    /// Start a new ``Span`` with the given `Baggage` at a given time.
+    ///
+    /// - Note: Prefer to use `withSpan` to start a span as it automatically takes care of ending the span,
+    /// and recording errors when thrown. Use `startSpan` iff you need to pass the span manually to a different
+    /// location in your source code to end it.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
+    func startSpan(
+        _ operationName: String,
+        baggage: Baggage,
+        ofKind kind: SpanKind,
+        at time: DispatchWallTime,
+        function: String,
+        file fileID: String,
+        line: UInt
+    ) -> Self.Span
+
+    /// Export all ended spans to the configured backend that have not yet been exported.
+    ///
+    /// This function should only be called in cases where it is absolutely necessary,
+    /// such as when using some FaaS providers that may suspend the process after an invocation, but before the backend exports the completed spans.
+    ///
+    /// This function should not block indefinitely, implementations should offer a configurable timeout for flush operations.
+    func forceFlush()
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+extension TracerProtocol {
+    /// Start a new ``Span`` with the given `Baggage` starting "now".
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: Baggage potentially containing trace identifiers of a parent ``Span``.
+    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
+    ///   - function: The function name in which the span was started.
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
+    public func startSpan(
+        _ operationName: String,
+        baggage: Baggage,
+        ofKind kind: SpanKind = .internal,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line
+    ) -> Self.Span {
+        self.startSpan(
+            operationName,
+            baggage: baggage,
+            ofKind: kind,
+            at: .now(),
+            function: function,
+            file: fileID,
+            line: line
+        )
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Starting spans: `withSpan`
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+extension TracerProtocol {
+    /// Execute a specific task within a newly created ``Span``.
+    ///
+    /// DO NOT `end()` the passed in span manually. It will be ended automatically when the `operation` returns.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: Baggage potentially containing trace identifiers of a parent ``Span``.
+    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
+    ///   - operation: operation to wrap in a span start/end and execute immediately
+    ///   - function: The function name in which the span was started.
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
+    /// - Returns: the value returned by `operation`
+    /// - Throws: the error the `operation` has thrown (if any)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+    public func withSpan<T>(
+        _ operationName: String,
+        baggage: Baggage,
+        ofKind kind: SpanKind = .internal,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        _ operation: (Self.Span) throws -> T
+    ) rethrows -> T {
+        let span = self.startSpan(
+            operationName,
+            baggage: baggage,
+            ofKind: kind,
+            at: .now(),
+            function: function,
+            file: fileID,
+            line: line
+        )
+        defer { span.end() }
+        do {
+            return try Baggage.$current.withValue(span.baggage) {
+                try operation(span)
+            }
+        } catch {
+            span.recordError(error)
+            throw error // rethrow
+        }
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: Starting spans: Task-local Baggage propagation
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
+extension TracerProtocol {
+    /// Execute the given operation within a newly created ``Span``,
+    /// started as a child of the currently stored task local `Baggage.current` or as a root span if `nil`.
+    ///
+    /// DO NOT `end()` the passed in span manually. It will be ended automatically when the `operation` returns.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
+    ///   - operation: operation to wrap in a span start/end and execute immediately
+    ///   - function: The function name in which the span was started.
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
+    /// - Returns: the value returned by `operation`
+    /// - Throws: the error the `operation` has thrown (if any)
+    public func withSpan<T>(
+        _ operationName: String,
+        ofKind kind: SpanKind = .internal,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        _ operation: (Self.Span) throws -> T
+    ) rethrows -> T {
+        try self.withSpan(
+            operationName,
+            baggage: .current ?? .topLevel,
+            ofKind: kind,
+            function: function,
+            file: fileID,
+            line: line
+        ) { span in
+            try Baggage.$current.withValue(span.baggage) {
+                try operation(span)
+            }
+        }
+    }
+
+    /// Execute the given async operation within a newly created ``Span``,
+    /// started as a child of the currently stored task local `Baggage.current` or as a root span if `nil`.
+    ///
+    /// DO NOT `end()` the passed in span manually. It will be ended automatically when the `operation` returns.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
+    ///   - operation: operation to wrap in a span start/end and execute immediately
+    ///   - function: The function name in which the span was started.
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
+    /// - Returns: the value returned by `operation`
+    /// - Throws: the error the `operation` has thrown (if any)
+    #if swift(>=5.7.0)
+    @_unsafeInheritExecutor
+    public func withSpan<T>(
+        _ operationName: String,
+        ofKind kind: SpanKind = .internal,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        _ operation: (Self.Span) async throws -> T
+    ) async rethrows -> T {
+        let span = self.startSpan(
+            operationName,
+            baggage: .current ?? .topLevel,
+            ofKind: kind,
+            function: function,
+            file: fileID,
+            line: line
+        )
+        defer { span.end() }
+        do {
+            return try await Baggage.$current.withValue(span.baggage) {
+                try await operation(span)
+            }
+        } catch {
+            span.recordError(error)
+            throw error // rethrow
+        }
+    }
+    #else
+    public func withSpan<T>(
+        _ operationName: String,
+        ofKind kind: SpanKind = .internal,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        _ operation: (Self.Span) async throws -> T
+    ) async rethrows -> T {
+        let span = self.startSpan(
+            operationName,
+            baggage: .current ?? .topLevel,
+            ofKind: kind,
+            function: function,
+            file: fileID,
+            line: line
+        )
+        defer { span.end() }
+        do {
+            return try await Baggage.$current.withValue(span.baggage) {
+                try await operation(span)
+            }
+        } catch {
+            span.recordError(error)
+            throw error // rethrow
+        }
+    }
+    #endif
+
+    /// Execute the given async operation within a newly created `Span`,
+    /// started as a child of the passed in `Baggage` or as a root span if `nil`.
+    ///
+    /// DO NOT `end()` the passed in span manually. It will be ended automatically when the `operation` returns.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
+    ///   - baggage: The baggage to be used for the newly created span. It may be obtained by the user manually from the `Baggage.current`,
+    //               task local and modified before passing into this function. The baggage will be made the current task-local baggage for the duration of the `operation`.
+    ///   - kind: The `SpanKind` of the `Span` to be created. Defaults to `.internal`.
+    ///   - operation: operation to wrap in a span start/end and execute immediately
+    ///   - function: The function name in which the span was started.
+    ///   - fileID: The `fileID` where the span was started.
+    ///   - line: The file line where the span was started.
+    /// - Returns: the value returned by `operation`
+    /// - Throws: the error the `operation` has thrown (if any)
+    #if swift(>=5.7.0)
+    @_unsafeInheritExecutor
+    public func withSpan<T>(
+        _ operationName: String,
+        baggage: Baggage,
+        ofKind kind: SpanKind = .internal,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        _ operation: (SpanProtocol) async throws -> T
+    ) async rethrows -> T {
+        let span = self.startSpan(operationName, baggage: baggage, ofKind: kind, function: function, file: fileID, line: line)
+        defer { span.end() }
+        do {
+            return try await Baggage.$current.withValue(span.baggage) {
+                try await operation(span)
+            }
+        } catch {
+            span.recordError(error)
+            throw error // rethrow
+        }
+    }
+    #else
+    public func withSpan<T>(
+        _ operationName: String,
+        baggage: Baggage,
+        ofKind kind: SpanKind = .internal,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        _ operation: (Self.Span) async throws -> T
+    ) async rethrows -> T {
+        let span = self.startSpan(operationName, baggage: baggage, ofKind: kind, function: function, file: fileID, line: line)
+        defer { span.end() }
+        do {
+            return try await Baggage.$current.withValue(span.baggage) {
+                try await operation(span)
+            }
+        } catch {
+            span.recordError(error)
+            throw error // rethrow
+        }
+    }
+    #endif
+}
+
+#endif // Swift 5.7

--- a/Sources/Tracing/TracerProtocol.swift
+++ b/Sources/Tracing/TracerProtocol.swift
@@ -20,17 +20,30 @@ import Dispatch
 // MARK: Tracer protocol
 
 #if swift(>=5.7.0)
-/// An `InstrumentProtocol` with added functionality for distributed tracing. It uses the span-based tracing model and is
-/// based on the OpenTracing/OpenTelemetry spec.
+/// A tracer capable of creating new trace spans.
+///
+/// A tracer is a special kind of instrument with the added ability to start a ``SpanProtocol``.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
 public protocol TracerProtocol: LegacyTracerProtocol {
+
+    /// The concrete type of span this tracer will be producing/
     associatedtype Span: SpanProtocol
 
-    /// Start a new ``Span`` with the given `Baggage` at a given time.
+    /// Start a new ``Span`` with the given `Baggage`.
     ///
-    /// - Note: Prefer to use `withSpan` to start a span as it automatically takes care of ending the span,
-    /// and recording errors when thrown. Use `startSpan` iff you need to pass the span manually to a different
-    /// location in your source code to end it.
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Note: Prefer ``withSpan(_:baggage:ofKind:at:function:file:line:operation:)`` to start
+    ///   a span as it automatically takes care of ending the span, and recording errors when thrown.
+    ///   Use `startSpan` iff you need to pass the span manually to a different
+    ///   location in your source code to end it.
+    ///
+    /// - Warning: You must `end()` the span when it the measured operation has completed explicitly,
+    ///   otherwise the span object will potentially never be released nor reported.
     ///
     /// - Parameters:
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
@@ -50,39 +63,48 @@ public protocol TracerProtocol: LegacyTracerProtocol {
         line: UInt
     ) -> Self.Span
 
-    /// Export all ended spans to the configured backend that have not yet been exported.
-    ///
-    /// This function should only be called in cases where it is absolutely necessary,
-    /// such as when using some FaaS providers that may suspend the process after an invocation, but before the backend exports the completed spans.
-    ///
-    /// This function should not block indefinitely, implementations should offer a configurable timeout for flush operations.
-    func forceFlush()
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
 extension TracerProtocol {
-    /// Start a new ``Span`` with the given `Baggage` starting "now".
+    /// Start a new ``Span`` with the given `Baggage`.
+    ///
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Note: Prefer ``withSpan(_:baggage:ofKind:at:function:file:line:operation:)`` to start
+    ///   a span as it automatically takes care of ending the span, and recording errors when thrown.
+    ///   Use `startSpan` iff you need to pass the span manually to a different
+    ///   location in your source code to end it.
+    ///
+    /// - Warning: You must `end()` the span when it the measured operation has completed explicitly,
+    ///   otherwise the span object will potentially never be released nor reported.
     ///
     /// - Parameters:
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-    ///   - baggage: Baggage potentially containing trace identifiers of a parent ``Span``.
-    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
-    ///   - function: The function name in which the span was started.
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
     public func startSpan(
         _ operationName: String,
-        baggage: Baggage,
+        baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
+        at time: DispatchWallTime = .now(),
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line
     ) -> Self.Span {
         self.startSpan(
             operationName,
-            baggage: baggage,
+            baggage: baggage(),
             ofKind: kind,
-            at: .now(),
+            at: time,
             function: function,
             file: fileID,
             line: line
@@ -95,25 +117,34 @@ extension TracerProtocol {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
 extension TracerProtocol {
-    /// Execute a specific task within a newly created ``Span``.
+    /// Start a new ``Span`` and automatically end when the `operation` completes,
+    /// including recording the `error` in case the operation throws.
     ///
-    /// DO NOT `end()` the passed in span manually. It will be ended automatically when the `operation` returns.
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Warning: You MUST NOT ``SpanProtocol/end()`` the span explicitly, because at the end of the `withSpan`
+    ///   operation closure returning the span will be closed automatically.
     ///
     /// - Parameters:
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-    ///   - baggage: Baggage potentially containing trace identifiers of a parent ``Span``.
-    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
-    ///   - operation: operation to wrap in a span start/end and execute immediately
-    ///   - function: The function name in which the span was started.
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
+    ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
     public func withSpan<T>(
         _ operationName: String,
-        baggage: Baggage,
+        baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
+        at time: DispatchWallTime = .now(),
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
@@ -121,9 +152,9 @@ extension TracerProtocol {
     ) rethrows -> T {
         let span = self.startSpan(
             operationName,
-            baggage: baggage,
+            baggage: baggage(),
             ofKind: kind,
-            at: .now(),
+            at: time,
             function: function,
             file: fileID,
             line: line
@@ -138,68 +169,36 @@ extension TracerProtocol {
             throw error // rethrow
         }
     }
-}
 
-// ==== ----------------------------------------------------------------------------------------------------------------
-// MARK: Starting spans: Task-local Baggage propagation
-
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
-extension TracerProtocol {
-    /// Execute the given operation within a newly created ``Span``,
-    /// started as a child of the currently stored task local `Baggage.current` or as a root span if `nil`.
+    /// Start a new ``Span`` and automatically end when the `operation` completes,
+    /// including recording the `error` in case the operation throws.
     ///
-    /// DO NOT `end()` the passed in span manually. It will be ended automatically when the `operation` returns.
+    /// The current task-local `Baggage` is picked up and provided to the underlying tracer.
+    /// It is also possible to pass a specific `baggage` explicitly, in which case attempting
+    /// to pick up the task-local baggage is prevented. This can be useful when we know that
+    /// we're about to start a top-level span, or if a span should be started from a different,
+    /// stored away previously,
+    ///
+    /// - Warning: You MUST NOT ``SpanProtocol/end()`` the span explicitly, because at the end of the `withSpan`
+    ///   operation closure returning the span will be closed automatically.
     ///
     /// - Parameters:
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
-    ///   - operation: operation to wrap in a span start/end and execute immediately
-    ///   - function: The function name in which the span was started.
+    ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
+    ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - time: The time at which to start the new ``Span``.
+    ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
+    ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-    public func withSpan<T>(
-        _ operationName: String,
-        ofKind kind: SpanKind = .internal,
-        function: String = #function,
-        file fileID: String = #fileID,
-        line: UInt = #line,
-        _ operation: (Self.Span) throws -> T
-    ) rethrows -> T {
-        try self.withSpan(
-            operationName,
-            baggage: .current ?? .topLevel,
-            ofKind: kind,
-            function: function,
-            file: fileID,
-            line: line
-        ) { span in
-            try Baggage.$current.withValue(span.baggage) {
-                try operation(span)
-            }
-        }
-    }
-
-    /// Execute the given async operation within a newly created ``Span``,
-    /// started as a child of the currently stored task local `Baggage.current` or as a root span if `nil`.
-    ///
-    /// DO NOT `end()` the passed in span manually. It will be ended automatically when the `operation` returns.
-    ///
-    /// - Parameters:
-    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-    ///   - kind: The ``SpanKind`` of the ``Span`` to be created. Defaults to ``SpanKind/internal``.
-    ///   - operation: operation to wrap in a span start/end and execute immediately
-    ///   - function: The function name in which the span was started.
-    ///   - fileID: The `fileID` where the span was started.
-    ///   - line: The file line where the span was started.
-    /// - Returns: the value returned by `operation`
-    /// - Throws: the error the `operation` has thrown (if any)
-    #if swift(>=5.7.0)
     @_unsafeInheritExecutor
     public func withSpan<T>(
         _ operationName: String,
+        baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
+        at time: DispatchWallTime = .now(),
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
@@ -207,8 +206,9 @@ extension TracerProtocol {
     ) async rethrows -> T {
         let span = self.startSpan(
             operationName,
-            baggage: .current ?? .topLevel,
+            baggage: baggage(),
             ofKind: kind,
+            at: time,
             function: function,
             file: fileID,
             line: line
@@ -223,95 +223,7 @@ extension TracerProtocol {
             throw error // rethrow
         }
     }
-    #else
-    public func withSpan<T>(
-        _ operationName: String,
-        ofKind kind: SpanKind = .internal,
-        function: String = #function,
-        file fileID: String = #fileID,
-        line: UInt = #line,
-        _ operation: (Self.Span) async throws -> T
-    ) async rethrows -> T {
-        let span = self.startSpan(
-            operationName,
-            baggage: .current ?? .topLevel,
-            ofKind: kind,
-            function: function,
-            file: fileID,
-            line: line
-        )
-        defer { span.end() }
-        do {
-            return try await Baggage.$current.withValue(span.baggage) {
-                try await operation(span)
-            }
-        } catch {
-            span.recordError(error)
-            throw error // rethrow
-        }
-    }
-    #endif
 
-    /// Execute the given async operation within a newly created `Span`,
-    /// started as a child of the passed in `Baggage` or as a root span if `nil`.
-    ///
-    /// DO NOT `end()` the passed in span manually. It will be ended automatically when the `operation` returns.
-    ///
-    /// - Parameters:
-    ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-    ///   - baggage: The baggage to be used for the newly created span. It may be obtained by the user manually from the `Baggage.current`,
-    //               task local and modified before passing into this function. The baggage will be made the current task-local baggage for the duration of the `operation`.
-    ///   - kind: The `SpanKind` of the `Span` to be created. Defaults to `.internal`.
-    ///   - operation: operation to wrap in a span start/end and execute immediately
-    ///   - function: The function name in which the span was started.
-    ///   - fileID: The `fileID` where the span was started.
-    ///   - line: The file line where the span was started.
-    /// - Returns: the value returned by `operation`
-    /// - Throws: the error the `operation` has thrown (if any)
-    #if swift(>=5.7.0)
-    @_unsafeInheritExecutor
-    public func withSpan<T>(
-        _ operationName: String,
-        baggage: Baggage,
-        ofKind kind: SpanKind = .internal,
-        function: String = #function,
-        file fileID: String = #fileID,
-        line: UInt = #line,
-        _ operation: (SpanProtocol) async throws -> T
-    ) async rethrows -> T {
-        let span = self.startSpan(operationName, baggage: baggage, ofKind: kind, function: function, file: fileID, line: line)
-        defer { span.end() }
-        do {
-            return try await Baggage.$current.withValue(span.baggage) {
-                try await operation(span)
-            }
-        } catch {
-            span.recordError(error)
-            throw error // rethrow
-        }
-    }
-    #else
-    public func withSpan<T>(
-        _ operationName: String,
-        baggage: Baggage,
-        ofKind kind: SpanKind = .internal,
-        function: String = #function,
-        file fileID: String = #fileID,
-        line: UInt = #line,
-        _ operation: (Self.Span) async throws -> T
-    ) async rethrows -> T {
-        let span = self.startSpan(operationName, baggage: baggage, ofKind: kind, function: function, file: fileID, line: line)
-        defer { span.end() }
-        do {
-            return try await Baggage.$current.withValue(span.baggage) {
-                try await operation(span)
-            }
-        } catch {
-            span.recordError(error)
-            throw error // rethrow
-        }
-    }
-    #endif
 }
 
 #endif // Swift 5.7

--- a/Sources/_TracingBenchmarks/SpanAttributesDSLBenchmark.swift
+++ b/Sources/_TracingBenchmarks/SpanAttributesDSLBenchmark.swift
@@ -69,10 +69,10 @@ public let SpanAttributesDSLBenchmarks: [BenchmarkInfo] = [
     ),
 ]
 
-private var span: Span!
+private var span: (any SpanProtocol)!
 
 private func setUp() {
-    span = InstrumentationSystem.tracer.startSpan("something", baggage: .topLevel)
+    span = InstrumentationSystem.legacyTracer.startAnySpan("something", baggage: .topLevel)
 }
 
 private func tearDown() {
@@ -86,14 +86,14 @@ func bench_empty(times: Int) throws {}
 
 func bench_makeSpan(times: Int) throws {
     for _ in 0 ..< times {
-        let span = InstrumentationSystem.tracer.startSpan("something", baggage: .topLevel)
+        let span = InstrumentationSystem.legacyTracer.startAnySpan("something", baggage: .topLevel)
         _ = span
     }
 }
 
 func bench_startSpan_end(times: Int) throws {
     for _ in 0 ..< times {
-        let span = InstrumentationSystem.tracer.startSpan("something", baggage: .topLevel)
+        let span = InstrumentationSystem.legacyTracer.startAnySpan("something", baggage: .topLevel)
         span.end()
     }
 }

--- a/Tests/InstrumentationTests/InstrumentTests.swift
+++ b/Tests/InstrumentationTests/InstrumentTests.swift
@@ -52,7 +52,7 @@ private struct DictionaryExtractor: Extractor {
     }
 }
 
-private final class FirstFakeTracer: Instrument {
+private final class FirstFakeTracer: InstrumentProtocol {
     enum TraceIDKey: BaggageKey {
         typealias Value = String
 
@@ -77,7 +77,7 @@ private final class FirstFakeTracer: Instrument {
     }
 }
 
-private final class SecondFakeTracer: Instrument {
+private final class SecondFakeTracer: InstrumentProtocol {
     enum TraceIDKey: BaggageKey {
         typealias Value = String
 

--- a/Tests/InstrumentationTests/InstrumentationSystemTests.swift
+++ b/Tests/InstrumentationTests/InstrumentationSystemTests.swift
@@ -17,7 +17,7 @@ import InstrumentationBaggage
 import XCTest
 
 extension InstrumentationSystem {
-    public static func _instrument<I>(of instrumentType: I.Type) -> I? where I: Instrument {
+    public static func _instrument<I>(of instrumentType: I.Type) -> I? where I: InstrumentProtocol {
         self._findInstrument(where: { $0 is I }) as? I
     }
 }
@@ -48,7 +48,7 @@ final class InstrumentationSystemTests: XCTestCase {
     }
 }
 
-private final class FakeTracer: Instrument {
+private final class FakeTracer: InstrumentProtocol {
     func inject<Carrier, Inject>(
         _ baggage: Baggage,
         into carrier: inout Carrier,
@@ -68,7 +68,7 @@ private final class FakeTracer: Instrument {
         Carrier == Extract.Carrier {}
 }
 
-private final class FakeInstrument: Instrument {
+private final class FakeInstrument: InstrumentProtocol {
     func inject<Carrier, Inject>(
         _ baggage: Baggage,
         into carrier: inout Carrier,

--- a/Tests/TracingTests/DynamicTracepointTracerTests.swift
+++ b/Tests/TracingTests/DynamicTracepointTracerTests.swift
@@ -159,12 +159,12 @@ final class DynamicTracepointTestTracer: LegacyTracerProtocol {
     }
 
     func startAnySpan(_ operationName: String,
-                   baggage: InstrumentationBaggage.Baggage,
-                   ofKind kind: Tracing.SpanKind,
-                   at time: DispatchWallTime,
-                   function: String,
-                   file fileID: String,
-                   line: UInt) -> any SpanProtocol
+                      baggage: InstrumentationBaggage.Baggage,
+                      ofKind kind: Tracing.SpanKind,
+                      at time: DispatchWallTime,
+                      function: String,
+                      file fileID: String,
+                      line: UInt) -> any SpanProtocol
     {
         let tracepoint = TracepointID(function: function, fileID: fileID, line: line)
         guard self.shouldRecord(tracepoint: tracepoint) else {
@@ -325,12 +325,13 @@ extension DynamicTracepointTestTracer {
 extension DynamicTracepointTestTracer: TracerProtocol {
     typealias Span = TracepointSpan
     func startSpan(_ operationName: String,
-                      baggage: InstrumentationBaggage.Baggage,
-                      ofKind kind: Tracing.SpanKind,
-                      at time: DispatchWallTime,
-                      function: String,
-                      file fileID: String,
-                      line: UInt) -> TracepointSpan {
+                   baggage: InstrumentationBaggage.Baggage,
+                   ofKind kind: Tracing.SpanKind,
+                   at time: DispatchWallTime,
+                   function: String,
+                   file fileID: String,
+                   line: UInt) -> TracepointSpan
+    {
         let tracepoint = TracepointID(function: function, fileID: fileID, line: line)
         guard self.shouldRecord(tracepoint: tracepoint) else {
             return TracepointSpan.notRecording(file: fileID, line: line)

--- a/Tests/TracingTests/DynamicTracepointTracerTests.swift
+++ b/Tests/TracingTests/DynamicTracepointTracerTests.swift
@@ -105,6 +105,11 @@ final class DynamicTracepointTracerTests: XCTestCase {
     func logic(fakeLine: UInt) {
         #if swift(>=5.7)
         InstrumentationSystem.tracer.withSpan("\(#function)-dont", line: fakeLine) { _ in
+            // inside
+        }
+        #else
+        InstrumentationSystem.legacyTracer.withAnySpan("\(#function)-dont", line: fakeLine) { _ in
+            // inside
         }
         #endif
     }
@@ -113,6 +118,12 @@ final class DynamicTracepointTracerTests: XCTestCase {
         #if swift(>=5.7)
         InstrumentationSystem.tracer.withSpan("\(#function)-yes", line: fakeLine) { _ in
             InstrumentationSystem.tracer.withSpan("\(#function)-yes-inside", line: fakeLine + 11) { _ in
+                // inside
+            }
+        }
+        #else
+        InstrumentationSystem.legacyTracer.withAnySpan("\(#function)-yes", line: fakeLine) { _ in
+            InstrumentationSystem.legacyTracer.withAnySpan("\(#function)-yes-inside", line: fakeLine + 11) { _ in
                 // inside
             }
         }

--- a/Tests/TracingTests/SpanTests.swift
+++ b/Tests/TracingTests/SpanTests.swift
@@ -70,7 +70,7 @@ final class SpanTests: XCTestCase {
     }
 
     func testSpanAttributeIsExpressibleByArrayLiteral() {
-        let s = InstrumentationSystem.tracer.startSpan("", baggage: .topLevel)
+        let s = InstrumentationSystem.legacyTracer.startAnySpan("", baggage: .topLevel)
         s.attributes["hi"] = [42, 21]
         s.attributes["hi"] = [42.10, 21.0]
         s.attributes["hi"] = [true, false]

--- a/Tests/TracingTests/TracedLock.swift
+++ b/Tests/TracingTests/TracedLock.swift
@@ -21,7 +21,7 @@ final class TracedLock {
     let name: String
     let underlyingLock: NSLock
 
-    var activeSpan: Span?
+    var activeSpan: SpanProtocol?
 
     init(name: String) {
         self.name = name
@@ -31,7 +31,7 @@ final class TracedLock {
     func lock(baggage: Baggage) {
         // time here
         self.underlyingLock.lock()
-        self.activeSpan = InstrumentationSystem.tracer.startSpan(self.name, baggage: baggage)
+        self.activeSpan = InstrumentationSystem.legacyTracer.startAnySpan(self.name, baggage: baggage)
     }
 
     func unlock(baggage: Baggage) {

--- a/Tests/TracingTests/TracedLockTests.swift
+++ b/Tests/TracingTests/TracedLockTests.swift
@@ -59,8 +59,8 @@ enum TaskIDKey: BaggageKey {
 // MARK: PrintLn Tracer
 
 /// Only intended to be used in single-threaded testing.
-private final class TracedLockPrintlnTracer: Tracer {
-    func startSpan(
+private final class TracedLockPrintlnTracer: LegacyTracerProtocol {
+    func startAnySpan(
         _ operationName: String,
         baggage: Baggage,
         ofKind kind: SpanKind,
@@ -68,7 +68,7 @@ private final class TracedLockPrintlnTracer: Tracer {
         function: String,
         file fileID: String,
         line: UInt
-    ) -> Span {
+    ) -> any SpanProtocol {
         TracedLockPrintlnSpan(
             operationName: operationName,
             startTime: time,
@@ -97,7 +97,7 @@ private final class TracedLockPrintlnTracer: Tracer {
         Extract: Extractor,
         Carrier == Extract.Carrier {}
 
-    final class TracedLockPrintlnSpan: Span {
+    final class TracedLockPrintlnSpan: SpanProtocol {
         private let kind: SpanKind
 
         private var status: SpanStatus?
@@ -159,6 +159,27 @@ private final class TracedLockPrintlnTracer: Tracer {
         }
     }
 }
+
+#if swift(>=5.7.0)
+extension TracedLockPrintlnTracer: TracerProtocol {
+    func startSpan(
+        _ operationName: String,
+        baggage: Baggage,
+        ofKind kind: SpanKind,
+        at time: DispatchWallTime,
+        function: String,
+        file fileID: String,
+        line: UInt
+    ) -> TracedLockPrintlnSpan {
+        TracedLockPrintlnSpan(
+            operationName: operationName,
+            startTime: time,
+            kind: kind,
+            baggage: baggage
+        )
+    }
+}
+#endif
 
 #if compiler(>=5.6.0)
 extension TracedLockPrintlnTracer: Sendable {}

--- a/Tests/TracingTests/TracerTests+XCTest.swift
+++ b/Tests/TracingTests/TracerTests+XCTest.swift
@@ -35,6 +35,8 @@ extension TracerTests {
                 ("testWithSpan_automaticBaggagePropagation_async", testWithSpan_automaticBaggagePropagation_async),
                 ("testWithSpan_enterFromNonAsyncCode_passBaggage_asyncOperation", testWithSpan_enterFromNonAsyncCode_passBaggage_asyncOperation),
                 ("testWithSpan_automaticBaggagePropagation_async_throws", testWithSpan_automaticBaggagePropagation_async_throws),
+                ("test_static_Tracer_withSpan_automaticBaggagePropagation_async_throws", test_static_Tracer_withSpan_automaticBaggagePropagation_async_throws),
+                ("test_static_Tracer_withSpan_automaticBaggagePropagation_throws", test_static_Tracer_withSpan_automaticBaggagePropagation_throws),
                 ("testWithSpan_recordErrorWithAttributes", testWithSpan_recordErrorWithAttributes),
            ]
    }

--- a/Tests/TracingTests/TracerTests.swift
+++ b/Tests/TracingTests/TracerTests.swift
@@ -60,7 +60,7 @@ final class TracerTests: XCTestCase {
     func testWithSpan_success() {
         guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
             return
-    }
+        }
         let tracer = TestTracer()
         InstrumentationSystem.bootstrapInternal(tracer)
         defer {

--- a/Tests/TracingTests/TracerTests.swift
+++ b/Tests/TracingTests/TracerTests.swift
@@ -58,6 +58,9 @@ final class TracerTests: XCTestCase {
     }
 
     func testWithSpan_success() {
+        guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+            return
+    }
         let tracer = TestTracer()
         InstrumentationSystem.bootstrapInternal(tracer)
         defer {
@@ -65,11 +68,19 @@ final class TracerTests: XCTestCase {
         }
 
         var spanEnded = false
-        tracer.onEndSpan = { _ in spanEnded = true }
+        tracer.onEndSpan = { _ in
+            spanEnded = true
+        }
 
+        #if swift(>=5.7.0)
         let value = tracer.withSpan("hello", baggage: .topLevel) { _ in
             "yes"
         }
+        #else
+        let value = tracer.withAnySpan("hello", baggage: .topLevel) { _ in
+            "yes"
+        }
+        #endif
 
         XCTAssertEqual(value, "yes")
         XCTAssertTrue(spanEnded)
@@ -86,7 +97,7 @@ final class TracerTests: XCTestCase {
         tracer.onEndSpan = { _ in spanEnded = true }
 
         do {
-            _ = try tracer.withSpan("hello", baggage: .topLevel) { _ in
+            _ = try tracer.withAnySpan("hello", baggage: .topLevel) { _ in
                 throw ExampleSpanError()
             }
         } catch {
@@ -112,11 +123,11 @@ final class TracerTests: XCTestCase {
         var spanEnded = false
         tracer.onEndSpan = { _ in spanEnded = true }
 
-        func operation(span: Span) -> String {
+        func operation(span: SpanProtocol) -> String {
             "world"
         }
 
-        let value = tracer.withSpan("hello") { (span: Span) -> String in
+        let value = tracer.withAnySpan("hello") { (span: SpanProtocol) -> String in
             XCTAssertEqual(span.baggage.traceID, Baggage.current?.traceID)
             return operation(span: span)
         }
@@ -141,12 +152,12 @@ final class TracerTests: XCTestCase {
         var spanEnded = false
         tracer.onEndSpan = { _ in spanEnded = true }
 
-        func operation(span: Span) throws -> String {
+        func operation(span: SpanProtocol) throws -> String {
             throw ExampleSpanError()
         }
 
         do {
-            _ = try tracer.withSpan("hello", operation)
+            _ = try tracer.withAnySpan("hello", operation)
         } catch {
             XCTAssertTrue(spanEnded)
             XCTAssertEqual(error as? ExampleSpanError, ExampleSpanError())
@@ -171,12 +182,12 @@ final class TracerTests: XCTestCase {
         var spanEnded = false
         tracer.onEndSpan = { _ in spanEnded = true }
 
-        func operation(span: Span) async throws -> String {
+        func operation(span: SpanProtocol) async throws -> String {
             "world"
         }
 
         try self.testAsync {
-            let value = try await tracer.withSpan("hello") { (span: Span) -> String in
+            let value = try await tracer.withAnySpan("hello") { (span: SpanProtocol) -> String in
                 XCTAssertEqual(span.baggage.traceID, Baggage.current?.traceID)
                 return try await operation(span: span)
             }
@@ -202,14 +213,14 @@ final class TracerTests: XCTestCase {
         var spanEnded = false
         tracer.onEndSpan = { _ in spanEnded = true }
 
-        func operation(span: Span) async -> String {
+        func operation(span: SpanProtocol) async -> String {
             "world"
         }
 
         self.testAsync {
             var fromNonAsyncWorld = Baggage.topLevel
             fromNonAsyncWorld.traceID = "1234-5678"
-            let value = await tracer.withSpan("hello", baggage: fromNonAsyncWorld) { (span: Span) -> String in
+            let value = await tracer.withAnySpan("hello", baggage: fromNonAsyncWorld) { (span: SpanProtocol) -> String in
                 XCTAssertEqual(span.baggage.traceID, Baggage.current?.traceID)
                 XCTAssertEqual(span.baggage.traceID, fromNonAsyncWorld.traceID)
                 return await operation(span: span)
@@ -236,13 +247,13 @@ final class TracerTests: XCTestCase {
         var spanEnded = false
         tracer.onEndSpan = { _ in spanEnded = true }
 
-        func operation(span: Span) async throws -> String {
+        func operation(span: SpanProtocol) async throws -> String {
             throw ExampleSpanError()
         }
 
         self.testAsync {
             do {
-                _ = try await tracer.withSpan("hello", operation)
+                _ = try await tracer.withAnySpan("hello", operation)
             } catch {
                 XCTAssertTrue(spanEnded)
                 XCTAssertEqual(error as? ExampleSpanError, ExampleSpanError())
@@ -271,7 +282,7 @@ final class TracerTests: XCTestCase {
         let errorToThrow = ExampleSpanError()
         let attrsForError: SpanAttributes = ["attr": "value"]
 
-        tracer.withSpan("hello") { span in
+        tracer.withAnySpan("hello") { span in
             span.recordError(errorToThrow, attributes: attrsForError)
         }
 
@@ -343,12 +354,14 @@ struct FakeHTTPServer {
     }
 
     func receive(_ request: FakeHTTPRequest) {
-        let tracer = InstrumentationSystem.tracer
-
         var baggage = Baggage.topLevel
         InstrumentationSystem.instrument.extract(request.headers, into: &baggage, using: HTTPHeadersExtractor())
 
-        let span = tracer.startSpan("GET \(request.path)", baggage: baggage)
+        #if swift(>=5.7.0)
+        let span = InstrumentationSystem.legacyTracer.startAnySpan("GET \(request.path)", baggage: baggage)
+        #else
+        let span = InstrumentationSystem.legacyTracer.startAnySpan("GET \(request.path)", baggage: baggage)
+        #endif
 
         let response = self.catchAllHandler(span.baggage, request, self.client)
         span.attributes["http.status"] = response.status
@@ -364,7 +377,11 @@ final class FakeHTTPClient {
 
     func performRequest(_ baggage: Baggage, request: FakeHTTPRequest) {
         var request = request
-        let span = InstrumentationSystem.tracer.startSpan("GET \(request.path)", baggage: baggage)
+        #if swift(>=5.7.0)
+        let span = InstrumentationSystem.legacyTracer.startAnySpan("GET \(request.path)", baggage: baggage)
+        #else
+        let span = InstrumentationSystem.legacyTracer.startAnySpan("GET \(request.path)", baggage: baggage)
+        #endif
         self.baggages.append(span.baggage)
         InstrumentationSystem.instrument.inject(baggage, into: &request.headers, using: HTTPHeadersInjector())
         span.end()


### PR DESCRIPTION
**Motivation:**

This is a revival of
https://github.com/apple/swift-distributed-tracing/pull/84 where we try to KEEP compatibility with versions below 5.7 with a compatibility "legacy" tracer type, but otherwise move towards requiring 5.7 for all the "nice" apis that use associated types and `any
  TracerProtocol` and friends

**Modifications:**

- `Tracer` -> `TracerProtocol`
- `Tracer` is now a namespace in order to `Tracer.withSpan {}` easily
- `Span` -> `SpanProtocol`
- Introduce `LegacyTracerProtocol` which does not make use of associated type Span, and can be used in 5.6 libraries; they can deprecate and move away form it ASAP as they start requiring 5.7

**Result:**

Offer the APIs we want in 5.7 but remain compatible with 5.6 until we drop it as soon as 5.9 is released as stable - this allows us to adopt eagerly in libraries without having to wait for 5.9 to drop.

Replaces https://github.com/apple/swift-distributed-tracing/pull/84