### PR TITLE
Provide explicit set/get to avoid SpanAttributeConvertible wrapping

### DIFF
--- a/Sources/Tracing/SpanProtocol.swift
+++ b/Sources/Tracing/SpanProtocol.swift
@@ -537,6 +537,16 @@ extension SpanAttributes {
         }
     }
 
+    /// Similar to `subscript(_:)` however returns the stored `SpanAttribute` rather than going through `SpanAttributeConvertible`.
+    public func get(_ name: String) -> SpanAttribute? {
+        self._attributes[name]
+    }
+
+    /// Similar to `subscript(_:)` however accepts a `SpanAttribute` rather than going through `SpanAttributeConvertible`.
+    public mutating func set(_ name: String, value: SpanAttribute?) {
+        self._attributes[name] = value
+    }
+
     /// - Parameter callback: The function to call for each attribute.
     public func forEach(_ callback: (String, SpanAttribute) -> Void) {
         self._attributes.forEach {


### PR DESCRIPTION
Provide explicit set/get to avoid SpanAttributeConvertible existential wrapping, to those who care about such overhead

**Motivation:**

Provide more control and allow avoiding the existential SpanAtrributeConvertible access when using the subscript.

**Modifications:**

additional API to avoid the existential

**Result:**
There is a way to use the API completely avoiding existentials

resolves https://github.com/apple/swift-distributed-tracing/issues/82