### PR TITLE
Default LegacyTracerProtocol implementation

### DIFF
--- a/Sources/Tracing/TracerProtocol.swift
+++ b/Sources/Tracing/TracerProtocol.swift
@@ -110,6 +110,21 @@ extension TracerProtocol {
     }
 }
 
+extension TracerProtocol {
+    // default implementation of the `LegacyTracerProtocol`
+    public func startAnySpan<Clock>(
+        _ operationName: String,
+        baggage: @autoclosure () -> InstrumentationBaggage.Baggage,
+        ofKind kind: Tracing.SpanKind,
+        clock: Clock,
+        function: String,
+        file fileID: String,
+        line: UInt
+    ) -> Tracing.Span where Clock: Tracing.TracerClock {
+        self.startSpan(operationName, baggage: baggage(), ofKind: kind, clock: clock, function: function, file: fileID, line: line)
+    }
+}
+
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Starting spans: `withSpan`
 


### PR DESCRIPTION
### Motivation

For adopters that implement the `TracerProtocol` we should offer a default implementation for the `LegacyTracerProtocol`, so that they don't need to worry about it at all.

### Changes

- Add default `LegacyTracerProtocol` implementation on `TracerProtocol`