### PR TITLE
consider TracerSpan assoc type -> Span

### DIFF
--- a/Sources/Tracing/NoOpTracer.swift
+++ b/Sources/Tracing/NoOpTracer.swift
@@ -19,7 +19,7 @@ import Dispatch
 /// Tracer that ignores all operations, used when no tracing is required.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
 public struct NoOpTracer: LegacyTracer {
-    public typealias TracerSpan = NoOpSpan
+    public typealias Span = NoOpSpan
 
     public init() {}
 
@@ -29,7 +29,7 @@ public struct NoOpTracer: LegacyTracer {
                                                  clock: Clock,
                                                  function: String,
                                                  file fileID: String,
-                                                 line: UInt) -> any Span
+                                                 line: UInt) -> any Tracing.Span
     {
         NoOpSpan(baggage: baggage())
     }
@@ -48,7 +48,7 @@ public struct NoOpTracer: LegacyTracer {
         // no-op
     }
 
-    public struct NoOpSpan: Span {
+    public struct NoOpSpan: Tracing.Span {
         public let baggage: Baggage
         public var isRecording: Bool {
             false

--- a/Sources/Tracing/TracerProtocol+Legacy.swift
+++ b/Sources/Tracing/TracerProtocol+Legacy.swift
@@ -54,7 +54,7 @@ public protocol LegacyTracer: Instrument {
         function: String,
         file fileID: String,
         line: UInt
-    ) -> any Span
+    ) -> any Tracing.Span
 
     /// Export all ended spans to the configured backend that have not yet been exported.
     ///
@@ -108,7 +108,7 @@ extension LegacyTracer {
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line
-    ) -> any Span {
+    ) -> any Tracing.Span {
         self.startAnySpan(
             operationName,
             baggage: baggage(),
@@ -155,7 +155,7 @@ extension LegacyTracer {
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line
-    ) -> any Span {
+    ) -> any Tracing.Span {
         self.startAnySpan(
             operationName,
             baggage: baggage(),
@@ -200,7 +200,7 @@ extension LegacyTracer {
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
-        _ operation: (any Span) throws -> T
+        _ operation: (any Tracing.Span) throws -> T
     ) rethrows -> T {
         let span = self.startAnySpan(
             operationName,
@@ -253,7 +253,7 @@ extension LegacyTracer {
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
-        _ operation: (any Span) throws -> T
+        _ operation: (any Tracing.Span) throws -> T
     ) rethrows -> T {
         try self.withAnySpan(
             operationName,
@@ -301,7 +301,7 @@ extension LegacyTracer {
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
-        _ operation: (any Span) async throws -> T
+        _ operation: (any Tracing.Span) async throws -> T
     ) async rethrows -> T {
         let span = self.startAnySpan(
             operationName,
@@ -354,7 +354,7 @@ extension LegacyTracer {
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
-        _ operation: (any Span) async throws -> T
+        _ operation: (any Tracing.Span) async throws -> T
     ) async rethrows -> T {
         let span = self.startAnySpan(
             operationName,
@@ -469,7 +469,7 @@ extension Tracer {
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
-        _ operation: (any Span) throws -> T
+        _ operation: (any Tracing.Span) throws -> T
     ) rethrows -> T {
         try self.withSpan(
             operationName,
@@ -524,7 +524,7 @@ extension Tracer {
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
-        @_inheritActorContext @_implicitSelfCapture _ operation: (any Span) async throws -> T
+        @_inheritActorContext @_implicitSelfCapture _ operation: (any Tracing.Span) async throws -> T
     ) async rethrows -> T {
         try await self.withSpan(
             operationName,

--- a/Sources/Tracing/TracerProtocol.swift
+++ b/Sources/Tracing/TracerProtocol.swift
@@ -26,7 +26,7 @@
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
 public protocol Tracer: LegacyTracer {
     /// The concrete type of span this tracer will be producing/
-    associatedtype TracerSpan: Span
+    associatedtype Span: Tracing.Span
 
     /// Start a new ``Span`` with the given `Baggage`.
     ///
@@ -60,7 +60,7 @@ public protocol Tracer: LegacyTracer {
         function: String,
         file fileID: String,
         line: UInt
-    ) -> TracerSpan
+    ) -> Self.Span
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
@@ -97,7 +97,7 @@ extension Tracer {
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line
-    ) -> TracerSpan {
+    ) -> Self.Span {
         self.startSpan(
             operationName,
             baggage: baggage(),
@@ -145,7 +145,7 @@ extension Tracer {
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
-        _ operation: (TracerSpan) throws -> T
+        _ operation: (Self.Span) throws -> T
     ) rethrows -> T {
         let span = self.startSpan(
             operationName,
@@ -197,7 +197,7 @@ extension Tracer {
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
-        _ operation: (TracerSpan) throws -> T
+        _ operation: (Self.Span) throws -> T
     ) rethrows -> T {
         let span = self.startSpan(
             operationName,
@@ -249,7 +249,7 @@ extension Tracer {
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
-        @_inheritActorContext @_implicitSelfCapture _ operation: (TracerSpan) async throws -> T
+        @_inheritActorContext @_implicitSelfCapture _ operation: (Self.Span) async throws -> T
     ) async rethrows -> T {
         let span = self.startSpan(
             operationName,
@@ -302,7 +302,7 @@ extension Tracer {
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
-        @_inheritActorContext @_implicitSelfCapture _ operation: (TracerSpan) async throws -> T
+        @_inheritActorContext @_implicitSelfCapture _ operation: (Self.Span) async throws -> T
     ) async rethrows -> T {
         let span = self.startSpan(
             operationName,

--- a/Sources/_TracingBenchmarks/SpanAttributesDSLBenchmark.swift
+++ b/Sources/_TracingBenchmarks/SpanAttributesDSLBenchmark.swift
@@ -69,7 +69,7 @@ public let SpanAttributesDSLBenchmarks: [BenchmarkInfo] = [
     ),
 ]
 
-private var span: (any Span)!
+private var span: (any Tracing.Span)!
 
 private func setUp() {
     span = InstrumentationSystem.legacyTracer.startAnySpan("something", baggage: .topLevel)

--- a/Tests/TracingTests/DynamicTracepointTracerTests.swift
+++ b/Tests/TracingTests/DynamicTracepointTracerTests.swift
@@ -162,7 +162,7 @@ final class DynamicTracepointTestTracer: LegacyTracer {
     }
 
     private(set) var spans: [TracepointSpan] = []
-    var onEndSpan: (any Span) -> Void = { _ in
+    var onEndSpan: (any Tracing.Span) -> Void = { _ in
     }
 
     func startAnySpan<Clock: TracerClock>(
@@ -173,7 +173,7 @@ final class DynamicTracepointTestTracer: LegacyTracer {
         function: String,
         file fileID: String,
         line: UInt
-    ) -> any Span {
+    ) -> any Tracing.Span {
         let tracepoint = TracepointID(function: function, fileID: fileID, line: line)
         guard self.shouldRecord(tracepoint: tracepoint) else {
             return TracepointSpan.notRecording(file: fileID, line: line)
@@ -331,7 +331,7 @@ extension DynamicTracepointTestTracer {
 
 #if compiler(>=5.7.0)
 extension DynamicTracepointTestTracer: Tracer {
-    typealias TracerSpan = TracepointSpan
+    typealias Span = TracepointSpan
 
     func startSpan<Clock: TracerClock>(_ operationName: String,
                                        baggage: @autoclosure () -> Baggage,

--- a/Tests/TracingTests/TestTracer.swift
+++ b/Tests/TracingTests/TestTracer.swift
@@ -31,7 +31,7 @@ final class TestTracer: LegacyTracer {
         function: String,
         file fileID: String,
         line: UInt
-    ) -> any Span {
+    ) -> any Tracing.Span {
         let span = TestSpan(
             operationName: operationName,
             startTime: clock.now,

--- a/Tests/TracingTests/TracedLock.swift
+++ b/Tests/TracingTests/TracedLock.swift
@@ -21,7 +21,7 @@ final class TracedLock {
     let name: String
     let underlyingLock: NSLock
 
-    var activeSpan: (any Span)?
+    var activeSpan: (any Tracing.Span)?
 
     init(name: String) {
         self.name = name

--- a/Tests/TracingTests/TracedLockTests.swift
+++ b/Tests/TracingTests/TracedLockTests.swift
@@ -68,7 +68,7 @@ private final class TracedLockPrintlnTracer: LegacyTracer {
         function: String,
         file fileID: String,
         line: UInt
-    ) -> any Span {
+    ) -> any Tracing.Span {
         TracedLockPrintlnSpan(
             operationName: operationName,
             startTime: clock.now,
@@ -97,7 +97,7 @@ private final class TracedLockPrintlnTracer: LegacyTracer {
         Extract: Extractor,
         Carrier == Extract.Carrier {}
 
-    final class TracedLockPrintlnSpan: Span {
+    final class TracedLockPrintlnSpan: Tracing.Span {
         private let kind: SpanKind
 
         private var status: SpanStatus?

--- a/Tests/TracingTests/TracerTests.swift
+++ b/Tests/TracingTests/TracerTests.swift
@@ -123,11 +123,11 @@ final class TracerTests: XCTestCase {
         var spanEnded = false
         tracer.onEndSpan = { _ in spanEnded = true }
 
-        func operation(span: any Span) -> String {
+        func operation(span: any Tracing.Span) -> String {
             "world"
         }
 
-        let value = tracer.withAnySpan("hello") { (span: any Span) -> String in
+        let value = tracer.withAnySpan("hello") { (span: any Tracing.Span) -> String in
             XCTAssertEqual(span.baggage.traceID, Baggage.current?.traceID)
             return operation(span: span)
         }
@@ -152,7 +152,7 @@ final class TracerTests: XCTestCase {
         var spanEnded = false
         tracer.onEndSpan = { _ in spanEnded = true }
 
-        func operation(span: any Span) throws -> String {
+        func operation(span: any Tracing.Span) throws -> String {
             throw ExampleSpanError()
         }
 
@@ -182,12 +182,12 @@ final class TracerTests: XCTestCase {
         var spanEnded = false
         tracer.onEndSpan = { _ in spanEnded = true }
 
-        func operation(span: any Span) async throws -> String {
+        func operation(span: any Tracing.Span) async throws -> String {
             "world"
         }
 
         try self.testAsync {
-            let value = try await tracer.withAnySpan("hello") { (span: any Span) -> String in
+            let value = try await tracer.withAnySpan("hello") { (span: any Tracing.Span) -> String in
                 XCTAssertEqual(span.baggage.traceID, Baggage.current?.traceID)
                 return try await operation(span: span)
             }
@@ -212,14 +212,14 @@ final class TracerTests: XCTestCase {
         var spanEnded = false
         tracer.onEndSpan = { _ in spanEnded = true }
 
-        func operation(span: any Span) async -> String {
+        func operation(span: any Tracing.Span) async -> String {
             "world"
         }
 
         self.testAsync {
             var fromNonAsyncWorld = Baggage.topLevel
             fromNonAsyncWorld.traceID = "1234-5678"
-            let value = await tracer.withAnySpan("hello", baggage: fromNonAsyncWorld) { (span: any Span) -> String in
+            let value = await tracer.withAnySpan("hello", baggage: fromNonAsyncWorld) { (span: any Tracing.Span) -> String in
                 XCTAssertEqual(span.baggage.traceID, Baggage.current?.traceID)
                 XCTAssertEqual(span.baggage.traceID, fromNonAsyncWorld.traceID)
                 return await operation(span: span)
@@ -244,7 +244,7 @@ final class TracerTests: XCTestCase {
         var spanEnded = false
         tracer.onEndSpan = { _ in spanEnded = true }
 
-        func operation(span: any Span) async throws -> String {
+        func operation(span: any Tracing.Span) async throws -> String {
             throw ExampleSpanError()
         }
 
@@ -274,7 +274,7 @@ final class TracerTests: XCTestCase {
         var spanEnded = false
         tracer.onEndSpan = { _ in spanEnded = true }
 
-        func operation(span: any Span) async throws -> String {
+        func operation(span: any Tracing.Span) async throws -> String {
             throw ExampleSpanError()
         }
 
@@ -304,7 +304,7 @@ final class TracerTests: XCTestCase {
         var spanEnded = false
         tracer.onEndSpan = { _ in spanEnded = true }
 
-        func operation(span: any Span) throws -> String {
+        func operation(span: any Tracing.Span) throws -> String {
             throw ExampleSpanError()
         }
 


### PR DESCRIPTION
Something @fabianfett requested we give another look at.

Resolves https://github.com/apple/swift-distributed-tracing/issues/110 but we should discuss this more -- it comes with a confusing tradeoff for implementers of spans I suppose. Please discuss. I'm on the fence, it is nice to not have `Tracer.TracerSpan` but the tradeoff is some potential confusion hmmm

**Motivation:**

Users who use generic `Tracer` end up having to spell `Tracer.TracerSpan`.

We could help those situations by renaming the associated type. However at the cost of causing name conflicts where the Span implementation must qualify that it is implementing `Tracing.Span`.

This may or may not be worth it -- discuss.

**Modifications:**

`associatedtype TracerSpan: Span` -> `associatedtype Span: Tracing.Span`