### PR TITLE
Add nanoseconds to instant protocol

### DIFF
--- a/Sources/Tracing/TracingTime.swift
+++ b/Sources/Tracing/TracingTime.swift
@@ -21,12 +21,12 @@ import Darwin
 @_exported import Instrumentation
 @_exported import InstrumentationBaggage
 
-public protocol TracerInstantProtocol: Comparable, Hashable, Sendable {
+public protocol TracerInstant: Comparable, Hashable, Sendable {
     /// Representation of this instant as the number of nanoseconds since UNIX Epoch (January 1st 1970)
     var nanosecondsSinceEpoch: UInt64 { get }
 }
 
-extension TracerInstantProtocol {
+extension TracerInstant {
     /// Representation of this instant as the number of milliseconds since UNIX Epoch (January 1st 1970)
     @inlinable
     public var millisecondsSinceEpoch: UInt64 {
@@ -46,7 +46,7 @@ extension TracerInstantProtocol {
 /// especially when the system is already using some notion of simulated or mocked time, such that traces are
 /// expressed using the same notion of time.
 public protocol TracerClock {
-    associatedtype Instant: TracerInstantProtocol
+    associatedtype Instant: TracerInstant
 
     var now: Self.Instant { get }
 }
@@ -59,7 +59,7 @@ public struct DefaultTracerClock: TracerClock {
         // empty
     }
 
-    public struct Timestamp: TracerInstantProtocol {
+    public struct Timestamp: TracerInstant {
         public let nanosecondsSinceEpoch: UInt64
 
         public init(nanosecondsSinceEpoch: UInt64) {

--- a/Sources/Tracing/TracingTime.swift
+++ b/Sources/Tracing/TracingTime.swift
@@ -21,26 +21,17 @@ import Darwin
 @_exported import Instrumentation
 @_exported import InstrumentationBaggage
 
-public protocol SwiftDistributedTracingDurationProtocol: Comparable, AdditiveArithmetic, Sendable {
-    static func / (_ lhs: Self, _ rhs: Int) -> Self
-    static func /= (_ lhs: inout Self, _ rhs: Int)
-    static func * (_ lhs: Self, _ rhs: Int) -> Self
-    static func *= (_ lhs: inout Self, _ rhs: Int)
-
-    static func / (_ lhs: Self, _ rhs: Self) -> Double
+public protocol TracerInstantProtocol: Comparable, Hashable, Sendable {
+    /// Representation of this instant as the number of nanoseconds since UNIX Epoch (January 1st 1970)
+    var nanosecondsSinceEpoch: UInt64 { get }
 }
 
-extension SwiftDistributedTracingDurationProtocol {
-    public static func /= (_ lhs: inout Self, _ rhs: Int) {
-        lhs = lhs / rhs
-    }
-}
-
-public protocol SwiftDistributedTracingInstantProtocol: Comparable, Hashable, Sendable {}
-
-public protocol TracerInstantProtocol: SwiftDistributedTracingInstantProtocol {
+extension TracerInstantProtocol {
     /// Representation of this instant as the number of milliseconds since UNIX Epoch (January 1st 1970)
-    var millisecondsSinceEpoch: UInt64 { get }
+    @inlinable
+    public var millisecondsSinceEpoch: UInt64 {
+        self.nanosecondsSinceEpoch / 1_000_000
+    }
 }
 
 /// A specialized clock protocol for purposes of tracing.
@@ -69,23 +60,22 @@ public struct DefaultTracerClock: TracerClock {
     }
 
     public struct Timestamp: TracerInstantProtocol {
-        /// Milliseconds since January 1st, 1970, also known as "unix epoch".
-        public var millisecondsSinceEpoch: UInt64
+        public let nanosecondsSinceEpoch: UInt64
 
-        internal init(millisecondsSinceEpoch: UInt64) {
-            self.millisecondsSinceEpoch = millisecondsSinceEpoch
+        public init(nanosecondsSinceEpoch: UInt64) {
+            self.nanosecondsSinceEpoch = nanosecondsSinceEpoch
         }
 
         public static func < (lhs: Instant, rhs: Instant) -> Bool {
-            lhs.millisecondsSinceEpoch < rhs.millisecondsSinceEpoch
+            lhs.nanosecondsSinceEpoch < rhs.nanosecondsSinceEpoch
         }
 
         public static func == (lhs: Instant, rhs: Instant) -> Bool {
-            lhs.millisecondsSinceEpoch == rhs.millisecondsSinceEpoch
+            lhs.nanosecondsSinceEpoch == rhs.nanosecondsSinceEpoch
         }
 
         public func hash(into hasher: inout Hasher) {
-            self.millisecondsSinceEpoch.hash(into: &hasher)
+            self.nanosecondsSinceEpoch.hash(into: &hasher)
         }
     }
 
@@ -100,8 +90,7 @@ public struct DefaultTracerClock: TracerClock {
         /// and the odds that this code will still be running 530 years from now is very, very low,
         /// so as a practical matter this will never overflow.
         let nowNanos = UInt64(ts.tv_sec) &* 1_000_000_000 &+ UInt64(ts.tv_nsec)
-        let nowMillis = UInt64(nowNanos / 1_000_000) // nanos to millis
 
-        return Instant(millisecondsSinceEpoch: nowMillis)
+        return Instant(nanosecondsSinceEpoch: nowNanos)
     }
 }

--- a/Tests/TracingTests/DynamicTracepointTracerTests.swift
+++ b/Tests/TracingTests/DynamicTracepointTracerTests.swift
@@ -281,13 +281,13 @@ extension DynamicTracepointTestTracer {
             return span
         }
 
-        init<Instant: TracerInstantProtocol>(operationName: String,
-                                             startTime: Instant,
-                                             baggage: Baggage,
-                                             kind: SpanKind,
-                                             file fileID: String,
-                                             line: UInt,
-                                             onEnd: @escaping (TracepointSpan) -> Void)
+        init<Instant: TracerInstant>(operationName: String,
+                                     startTime: Instant,
+                                     baggage: Baggage,
+                                     kind: SpanKind,
+                                     file fileID: String,
+                                     line: UInt,
+                                     onEnd: @escaping (TracepointSpan) -> Void)
         {
             self.operationName = operationName
             self.startTimestampNanosSinceEpoch = startTime.nanosecondsSinceEpoch

--- a/Tests/TracingTests/DynamicTracepointTracerTests.swift
+++ b/Tests/TracingTests/DynamicTracepointTracerTests.swift
@@ -258,8 +258,8 @@ extension DynamicTracepointTestTracer {
 
         private var status: SpanStatus?
 
-        private let startTime: UInt64
-        private(set) var endTime: UInt64?
+        private let startTimestampNanosSinceEpoch: UInt64
+        private(set) var endTimestampNanosSinceEpoch: UInt64?
 
         public var operationName: String
         private(set) var baggage: Baggage
@@ -290,7 +290,7 @@ extension DynamicTracepointTestTracer {
                                              onEnd: @escaping (TracepointSpan) -> Void)
         {
             self.operationName = operationName
-            self.startTime = startTime.millisecondsSinceEpoch
+            self.startTimestampNanosSinceEpoch = startTime.nanosecondsSinceEpoch
             self.baggage = baggage
             self.onEnd = onEnd
             self.kind = kind
@@ -323,7 +323,7 @@ extension DynamicTracepointTestTracer {
         }
 
         func end<Clock: TracerClock>(clock: Clock) {
-            self.endTime = clock.now.millisecondsSinceEpoch
+            self.endTimestampNanosSinceEpoch = clock.now.nanosecondsSinceEpoch
             self.onEnd(self)
         }
     }

--- a/Tests/TracingTests/TestTracer.swift
+++ b/Tests/TracingTests/TestTracer.swift
@@ -124,8 +124,8 @@ final class TestSpan: Span {
 
     private var status: SpanStatus?
 
-    public let startTime: UInt64
-    public private(set) var endTime: UInt64?
+    public let startTimestampNanosSinceEpoch: UInt64
+    public private(set) var endTimestampNanosSinceEpoch: UInt64?
 
     private(set) var recordedErrors: [(Error, SpanAttributes)] = []
 
@@ -158,7 +158,7 @@ final class TestSpan: Span {
         onEnd: @escaping (TestSpan) -> Void
     ) {
         self.operationName = operationName
-        self.startTime = startTime.millisecondsSinceEpoch
+        self.startTimestampNanosSinceEpoch = startTime.nanosecondsSinceEpoch
         self.baggage = baggage
         self.onEnd = onEnd
         self.kind = kind
@@ -182,7 +182,7 @@ final class TestSpan: Span {
     }
 
     func end<Clock: TracerClock>(clock: Clock) {
-        self.endTime = clock.now.millisecondsSinceEpoch
+        self.endTimestampNanosSinceEpoch = clock.now.nanosecondsSinceEpoch
         self.onEnd(self)
     }
 }

--- a/Tests/TracingTests/TestTracer.swift
+++ b/Tests/TracingTests/TestTracer.swift
@@ -150,7 +150,7 @@ final class TestSpan: Span {
 
     let onEnd: (TestSpan) -> Void
 
-    init<Instant: TracerInstantProtocol>(
+    init<Instant: TracerInstant>(
         operationName: String,
         startTime: Instant,
         baggage: Baggage,

--- a/Tests/TracingTests/TracedLockTests.swift
+++ b/Tests/TracingTests/TracedLockTests.swift
@@ -124,7 +124,7 @@ private final class TracedLockPrintlnTracer: LegacyTracer {
 
         private(set) var isRecording = false
 
-        init<Instant: TracerInstantProtocol>(
+        init<Instant: TracerInstant>(
             operationName: String,
             startTime: Instant,
             kind: SpanKind,

--- a/Tests/TracingTests/TracerTests+swift57.swift
+++ b/Tests/TracingTests/TracerTests+swift57.swift
@@ -91,7 +91,7 @@ final class SampleSwift57Span: Span {
 
     let onEnd: (SampleSwift57Span) -> Void
 
-    init<Instant: TracerInstantProtocol>(
+    init<Instant: TracerInstant>(
         operationName: String,
         startTime: Instant,
         baggage: Baggage,

--- a/Tests/TracingTests/TracerTimeTests.swift
+++ b/Tests/TracingTests/TracerTimeTests.swift
@@ -47,7 +47,7 @@ final class TracerTimeTests: XCTestCase {
         XCTAssertEqual(span.startTimestampNanosSinceEpoch, 13)
         #else
         let span: TestSpan = tracer.startAnySpan("start", clock: mockClock) as! TestSpan
-        XCTAssertEqual(span.startTime, 13)
+        XCTAssertEqual(span.startTimestampNanosSinceEpoch, 13)
         #endif
     }
 }

--- a/Tests/TracingTests/TracerTimeTests.swift
+++ b/Tests/TracingTests/TracerTimeTests.swift
@@ -44,7 +44,7 @@ final class TracerTimeTests: XCTestCase {
         mockClock.setTime(13)
         #if swift(>=5.7.0)
         let span: TestSpan = tracer.startSpan("start", clock: mockClock)
-        XCTAssertEqual(span.startTime, 13)
+        XCTAssertEqual(span.startTimestampNanosSinceEpoch, 13)
         #else
         let span: TestSpan = tracer.startAnySpan("start", clock: mockClock) as! TestSpan
         XCTAssertEqual(span.startTime, 13)
@@ -62,13 +62,13 @@ final class MockClock: TracerClock {
     }
 
     struct Instant: TracerInstantProtocol {
-        var millisecondsSinceEpoch: UInt64
+        var nanosecondsSinceEpoch: UInt64
         static func < (lhs: MockClock.Instant, rhs: MockClock.Instant) -> Bool {
-            lhs.millisecondsSinceEpoch < rhs.millisecondsSinceEpoch
+            lhs.nanosecondsSinceEpoch < rhs.nanosecondsSinceEpoch
         }
     }
 
     var now: Instant {
-        Instant(millisecondsSinceEpoch: self._now)
+        Instant(nanosecondsSinceEpoch: self._now)
     }
 }

--- a/Tests/TracingTests/TracerTimeTests.swift
+++ b/Tests/TracingTests/TracerTimeTests.swift
@@ -61,7 +61,7 @@ final class MockClock: TracerClock {
         self._now = time
     }
 
-    struct Instant: TracerInstantProtocol {
+    struct Instant: TracerInstant {
         var nanosecondsSinceEpoch: UInt64
         static func < (lhs: MockClock.Instant, rhs: MockClock.Instant) -> Bool {
             lhs.nanosecondsSinceEpoch < rhs.nanosecondsSinceEpoch


### PR DESCRIPTION
**Motivation:**

we have nanoseconds precision on most platforms so lets expose it.

resolves https://github.com/apple/swift-distributed-tracing/issues/105