### PR TITLE
remove clock protocol, use autoclosure "now" instant

### DIFF
--- a/Sources/Tracing/NoOpTracer.swift
+++ b/Sources/Tracing/NoOpTracer.swift
@@ -23,13 +23,13 @@ public struct NoOpTracer: LegacyTracer {
 
     public init() {}
 
-    public func startAnySpan<Clock: TracerClock>(_ operationName: String,
-                                                 baggage: @autoclosure () -> Baggage,
-                                                 ofKind kind: SpanKind,
-                                                 clock: Clock,
-                                                 function: String,
-                                                 file fileID: String,
-                                                 line: UInt) -> any Span
+    public func startAnySpan<Instant: TracerInstant>(_ operationName: String,
+                                                     baggage: @autoclosure () -> Baggage,
+                                                     ofKind kind: SpanKind,
+                                                     at instant: @autoclosure () -> Instant,
+                                                     function: String,
+                                                     file fileID: String,
+                                                     line: UInt) -> any Span
     {
         NoOpSpan(baggage: baggage())
     }
@@ -73,7 +73,7 @@ public struct NoOpTracer: LegacyTracer {
 
         public func addEvent(_ event: SpanEvent) {}
 
-        public func recordError(_ error: Error, attributes: SpanAttributes) {}
+        public func recordError<Instant: TracerInstant>(_ error: Error, attributes: SpanAttributes, at instant: @autoclosure () -> Instant) {}
 
         public var attributes: SpanAttributes {
             get {
@@ -84,7 +84,7 @@ public struct NoOpTracer: LegacyTracer {
             }
         }
 
-        public func end<Clock: TracerClock>(clock: Clock) {
+        public func end<Instant: TracerInstant>(at instant: Instant) {
             // ignore
         }
     }
@@ -92,11 +92,11 @@ public struct NoOpTracer: LegacyTracer {
 
 #if swift(>=5.7.0)
 extension NoOpTracer: Tracer {
-    public func startSpan<Clock: TracerClock>(
+    public func startSpan<Instant: TracerInstant>(
         _ operationName: String,
         baggage: @autoclosure () -> Baggage,
         ofKind kind: SpanKind,
-        clock: Clock,
+        at instant: @autoclosure () -> Instant,
         function: String,
         file fileID: String,
         line: UInt

--- a/Sources/Tracing/Tracer.swift
+++ b/Sources/Tracing/Tracer.swift
@@ -34,16 +34,16 @@ import Dispatch
 ///
 /// - Parameters:
 ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-///   - clock: The clock to use as time source for the start time of the ``Span``
+///   - instant: the time instant at which the span started
 ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
 ///   - kind: The ``SpanKind`` of the new ``Span``.
 ///   - function: The function name in which the span was started
 ///   - fileID: The `fileID` where the span was started.
 ///   - line: The file line where the span was started.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
-public func startSpan<Clock: TracerClock>(
+public func startSpan<Instant: TracerInstant>(
     _ operationName: String,
-    clock: Clock,
+    at instant: @autoclosure () -> Instant,
     baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
     ofKind kind: SpanKind = .internal,
     function: String = #function,
@@ -54,7 +54,7 @@ public func startSpan<Clock: TracerClock>(
     // we try to not use the deprecated methods ourselves anyway
     InstrumentationSystem.legacyTracer.startAnySpan(
         operationName,
-        clock: clock,
+        at: instant(),
         baggage: baggage(),
         ofKind: kind,
         function: function,
@@ -99,7 +99,7 @@ public func startSpan(
     // we try to not use the deprecated methods ourselves anyway
     InstrumentationSystem.legacyTracer.startAnySpan(
         operationName,
-        clock: DefaultTracerClock(),
+        at: DefaultTracerClock.now,
         baggage: baggage(),
         ofKind: kind,
         function: function,
@@ -129,7 +129,7 @@ public func startSpan(
 ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
 ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
 ///   - kind: The ``SpanKind`` of the new ``Span``.
-///   - clock: The clock to use as time source for the start time of the ``Span``
+///   - instant: the time instant at which the span started
 ///   - function: The function name in which the span was started
 ///   - fileID: The `fileID` where the span was started.
 ///   - line: The file line where the span was started.
@@ -138,7 +138,7 @@ public func startSpan(
     _ operationName: String,
     baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
     ofKind kind: SpanKind = .internal,
-    clock: some TracerClock = DefaultTracerClock(),
+    at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
     function: String = #function,
     file fileID: String = #fileID,
     line: UInt = #line
@@ -147,7 +147,7 @@ public func startSpan(
     // we try to not use the deprecated methods ourselves anyway
     InstrumentationSystem.tracer.startAnySpan(
         operationName,
-        clock: clock,
+        at: instant(),
         baggage: baggage(),
         ofKind: kind,
         function: function,
@@ -173,7 +173,7 @@ public func startSpan(
 ///
 /// - Parameters:
 ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-///   - clock: The clock to use as time source for the start time of the ``Span``
+///   - instant: the time instant at which the span started
 ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
 ///   - kind: The ``SpanKind`` of the new ``Span``.
 ///   - function: The function name in which the span was started
@@ -183,9 +183,9 @@ public func startSpan(
 /// - Returns: the value returned by `operation`
 /// - Throws: the error the `operation` has thrown (if any)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
-public func withSpan<T, Clock: TracerClock>(
+public func withSpan<T, Instant: TracerInstant>(
     _ operationName: String,
-    clock: Clock,
+    at instant: @autoclosure () -> Instant,
     baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
     ofKind kind: SpanKind = .internal,
     function: String = #function,
@@ -195,7 +195,7 @@ public func withSpan<T, Clock: TracerClock>(
 ) rethrows -> T {
     try InstrumentationSystem.legacyTracer.withAnySpan(
         operationName,
-        clock: DefaultTracerClock(),
+        at: DefaultTracerClock.now,
         baggage: baggage(),
         ofKind: kind,
         function: function,
@@ -240,7 +240,7 @@ public func withSpan<T>(
 ) rethrows -> T {
     try InstrumentationSystem.legacyTracer.withAnySpan(
         operationName,
-        clock: DefaultTracerClock(),
+        at: DefaultTracerClock.now,
         baggage: baggage(),
         ofKind: kind,
         function: function,
@@ -267,7 +267,7 @@ public func withSpan<T>(
 ///
 /// - Parameters:
 ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-///   - clock: The clock to use as time source for the start time of the ``Span``
+///   - instant: the time instant at which the span started
 ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
 ///   - kind: The ``SpanKind`` of the new ``Span``.
 ///   - function: The function name in which the span was started
@@ -280,7 +280,7 @@ public func withSpan<T>(
     _ operationName: String,
     baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
     ofKind kind: SpanKind = .internal,
-    clock: some TracerClock = DefaultTracerClock(),
+    at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
     function: String = #function,
     file fileID: String = #fileID,
     line: UInt = #line,
@@ -288,7 +288,7 @@ public func withSpan<T>(
 ) rethrows -> T {
     try InstrumentationSystem.legacyTracer.withAnySpan(
         operationName,
-        clock: clock,
+        at: instant(),
         baggage: baggage(),
         ofKind: kind,
         function: function,
@@ -316,7 +316,7 @@ public func withSpan<T>(
 ///
 /// - Parameters:
 ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
-///   - clock: The clock to use as time source for the start time of the ``Span``
+///   - instant: the time instant at which the span started
 ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
 ///   - kind: The ``SpanKind`` of the new ``Span``.
 ///   - function: The function name in which the span was started
@@ -326,9 +326,9 @@ public func withSpan<T>(
 /// - Returns: the value returned by `operation`
 /// - Throws: the error the `operation` has thrown (if any)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal Baggage
-public func withSpan<T, Clock: TracerClock>(
+public func withSpan<T, Instant: TracerInstant>(
     _ operationName: String,
-    clock: Clock,
+    at instant: @autoclosure () -> Instant,
     baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
     ofKind kind: SpanKind = .internal,
     function: String = #function,
@@ -338,7 +338,7 @@ public func withSpan<T, Clock: TracerClock>(
 ) async rethrows -> T {
     try await InstrumentationSystem.legacyTracer.withAnySpan(
         operationName,
-        clock: DefaultTracerClock(),
+        at: DefaultTracerClock.now,
         baggage: baggage(),
         ofKind: kind,
         function: function,
@@ -383,7 +383,7 @@ public func withSpan<T>(
 ) async rethrows -> T {
     try await InstrumentationSystem.legacyTracer.withAnySpan(
         operationName,
-        clock: DefaultTracerClock(),
+        at: DefaultTracerClock.now,
         baggage: baggage(),
         ofKind: kind,
         function: function,
@@ -411,7 +411,7 @@ public func withSpan<T>(
 ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
 ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
 ///   - kind: The ``SpanKind`` of the new ``Span``.
-///   - clock: The clock to use as time source for the start time of the ``Span``
+///   - instant: the time instant at which the span started
 ///   - function: The function name in which the span was started
 ///   - fileID: The `fileID` where the span was started.
 ///   - line: The file line where the span was started.
@@ -422,7 +422,7 @@ public func withSpan<T>(
     _ operationName: String,
     baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
     ofKind kind: SpanKind = .internal,
-    clock: some TracerClock = DefaultTracerClock(),
+    at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
     function: String = #function,
     file fileID: String = #fileID,
     line: UInt = #line,
@@ -430,7 +430,7 @@ public func withSpan<T>(
 ) async rethrows -> T {
     try await InstrumentationSystem.legacyTracer.withAnySpan(
         operationName,
-        clock: clock,
+        at: instant(),
         baggage: baggage(),
         ofKind: kind,
         function: function,

--- a/Sources/Tracing/TracerProtocol+Legacy.swift
+++ b/Sources/Tracing/TracerProtocol+Legacy.swift
@@ -42,15 +42,15 @@ public protocol LegacyTracer: Instrument {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
-    ///   - clock: The clock to use as time source for the start time of the ``Span``
+    ///   - instant: the time instant at which the span started
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
-    func startAnySpan<Clock: TracerClock>(
+    func startAnySpan<Instant: TracerInstant>(
         _ operationName: String,
         baggage: @autoclosure () -> Baggage,
         ofKind kind: SpanKind,
-        clock: Clock,
+        at instant: @autoclosure () -> Instant,
         function: String,
         file fileID: String,
         line: UInt
@@ -96,13 +96,13 @@ extension LegacyTracer {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
-    ///   - clock: The clock to use as time source for the start time of the ``Span``
+    ///   - instant: the time instant at which the span started
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
-    public func startAnySpan<Clock: TracerClock>(
+    public func startAnySpan<Instant: TracerInstant>(
         _ operationName: String,
-        clock: Clock,
+        at instant: @autoclosure () -> Instant,
         baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
         function: String = #function,
@@ -113,7 +113,7 @@ extension LegacyTracer {
             operationName,
             baggage: baggage(),
             ofKind: kind,
-            clock: clock,
+            at: instant(),
             function: function,
             file: fileID,
             line: line
@@ -160,7 +160,7 @@ extension LegacyTracer {
             operationName,
             baggage: baggage(),
             ofKind: kind,
-            clock: DefaultTracerClock(),
+            at: DefaultTracerClock.now,
             function: function,
             file: fileID,
             line: line
@@ -185,16 +185,16 @@ extension LegacyTracer {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
-    ///   - clock: The clock to use as time source for the start time of the ``Span``
+    ///   - instant: the time instant at which the span started
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-    public func withAnySpan<T, Clock: TracerClock>(
+    public func withAnySpan<T, Instant: TracerInstant>(
         _ operationName: String,
-        clock: Clock,
+        at instant: @autoclosure () -> Instant,
         baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
         function: String = #function,
@@ -206,7 +206,7 @@ extension LegacyTracer {
             operationName,
             baggage: baggage(),
             ofKind: kind,
-            clock: clock,
+            at: instant(),
             function: function,
             file: fileID,
             line: line
@@ -257,7 +257,7 @@ extension LegacyTracer {
     ) rethrows -> T {
         try self.withAnySpan(
             operationName,
-            clock: DefaultTracerClock(),
+            at: DefaultTracerClock.now,
             baggage: baggage(),
             ofKind: kind,
             function: function,
@@ -293,9 +293,9 @@ extension LegacyTracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-    public func withAnySpan<T, Clock: TracerClock>(
+    public func withAnySpan<T, Instant: TracerInstant>(
         _ operationName: String,
-        clock: Clock,
+        at instant: @autoclosure () -> Instant,
         baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
         function: String = #function,
@@ -305,7 +305,7 @@ extension LegacyTracer {
     ) async rethrows -> T {
         let span = self.startAnySpan(
             operationName,
-            clock: clock,
+            at: instant(),
             baggage: baggage(),
             ofKind: kind,
             function: function,
@@ -358,7 +358,7 @@ extension LegacyTracer {
     ) async rethrows -> T {
         let span = self.startAnySpan(
             operationName,
-            clock: DefaultTracerClock(),
+            at: DefaultTracerClock.now,
             baggage: baggage(),
             ofKind: kind,
             function: function,
@@ -405,15 +405,15 @@ extension Tracer {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
-    ///   - clock: The clock to use as time source for the start time of the ``Span``
+    ///   - instant: the time instant at which the span started
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
-    public func startAnySpan<Clock: TracerClock>(
+    public func startAnySpan<Instant: TracerInstant>(
         _ operationName: String,
         baggage: @autoclosure () -> InstrumentationBaggage.Baggage,
         ofKind kind: Tracing.SpanKind,
-        clock: Clock,
+        at instant: @autoclosure () -> Instant,
         function: String,
         file fileID: String,
         line: UInt
@@ -422,7 +422,7 @@ extension Tracer {
             operationName,
             baggage: baggage(),
             ofKind: kind,
-            clock: clock,
+            at: instant(),
             function: function,
             file: fileID,
             line: line
@@ -454,7 +454,7 @@ extension Tracer {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
-    ///   - clock: The clock to use as time source for the start time of the ``Span``
+    ///   - instant: the time instant at which the span started
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
@@ -463,7 +463,7 @@ extension Tracer {
     /// - Throws: the error the `operation` has thrown (if any)
     public func withAnySpan<T>(
         _ operationName: String,
-        clock: some TracerClock = DefaultTracerClock(),
+        at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
         baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
         function: String = #function,
@@ -475,7 +475,7 @@ extension Tracer {
             operationName,
             baggage: baggage(),
             ofKind: kind,
-            clock: clock,
+            at: instant(),
             function: function,
             file: fileID,
             line: line
@@ -509,7 +509,7 @@ extension Tracer {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
-    ///   - clock: The clock to use as time source for the start time of the ``Span``
+    ///   - instant: the time instant at which the span started
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
@@ -518,7 +518,7 @@ extension Tracer {
     /// - Throws: the error the `operation` has thrown (if any)
     public func withAnySpan<T>(
         _ operationName: String,
-        clock: some TracerClock = DefaultTracerClock(),
+        at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
         baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
         function: String = #function,
@@ -530,7 +530,7 @@ extension Tracer {
             operationName,
             baggage: baggage(),
             ofKind: kind,
-            clock: clock,
+            at: instant(),
             function: function,
             file: fileID,
             line: line

--- a/Sources/Tracing/TracerProtocol.swift
+++ b/Sources/Tracing/TracerProtocol.swift
@@ -48,15 +48,15 @@ public protocol Tracer: LegacyTracer {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
-    ///   - clock: The clock to use as time source for the start time of the ``Span``
+    ///   - instant: the time instant at which the span started
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
-    func startSpan<Clock: TracerClock>(
+    func startSpan<Instant: TracerInstant>(
         _ operationName: String,
         baggage: @autoclosure () -> Baggage,
         ofKind kind: SpanKind,
-        clock: Clock,
+        at instant: @autoclosure () -> Instant,
         function: String,
         file fileID: String,
         line: UInt
@@ -85,7 +85,7 @@ extension Tracer {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
-    ///   - clock: The clock to use as time source for the start time of the ``Span``
+    ///   - instant: the time instant at which the span started
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
@@ -93,7 +93,7 @@ extension Tracer {
         _ operationName: String,
         baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
-        clock: some TracerClock = DefaultTracerClock(),
+        at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line
@@ -102,7 +102,7 @@ extension Tracer {
             operationName,
             baggage: baggage(),
             ofKind: kind,
-            clock: clock,
+            at: instant(),
             function: function,
             file: fileID,
             line: line
@@ -130,7 +130,7 @@ extension Tracer {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
-    ///   - clock: The clock to use as time source for the start time of the ``Span``
+    ///   - instant: the time instant at which the span started
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
@@ -141,7 +141,7 @@ extension Tracer {
         _ operationName: String,
         baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
-        clock: some TracerClock = DefaultTracerClock(),
+        at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
@@ -151,7 +151,7 @@ extension Tracer {
             operationName,
             baggage: baggage(),
             ofKind: kind,
-            clock: clock,
+            at: instant(),
             function: function,
             file: fileID,
             line: line
@@ -183,7 +183,7 @@ extension Tracer {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
-    ///   - clock: The clock to use as time source for the start time of the ``Span``
+    ///   - instant: the time instant at which the span started
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
@@ -203,7 +203,7 @@ extension Tracer {
             operationName,
             baggage: baggage(),
             ofKind: kind,
-            clock: DefaultTracerClock(),
+            at: DefaultTracerClock.now,
             function: function,
             file: fileID,
             line: line
@@ -235,7 +235,7 @@ extension Tracer {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
-    ///   - clock: The clock to use as time source for the start time of the ``Span``
+    ///   - instant: the time instant at which the span started
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
@@ -255,7 +255,7 @@ extension Tracer {
             operationName,
             baggage: baggage(),
             ofKind: kind,
-            clock: DefaultTracerClock(),
+            at: DefaultTracerClock.now,
             function: function,
             file: fileID,
             line: line
@@ -287,7 +287,7 @@ extension Tracer {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - baggage: The `Baggage` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
-    ///   - clock: The clock to use as time source for the start time of the ``Span``
+    ///   - instant: the time instant at which the span started
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
@@ -298,7 +298,7 @@ extension Tracer {
         _ operationName: String,
         baggage: @autoclosure () -> Baggage = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
-        clock: some TracerClock = DefaultTracerClock(),
+        at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
@@ -308,7 +308,7 @@ extension Tracer {
             operationName,
             baggage: baggage(),
             ofKind: kind,
-            clock: clock,
+            at: instant(),
             function: function,
             file: fileID,
             line: line

--- a/Sources/Tracing/TracingTime.swift
+++ b/Sources/Tracing/TracingTime.swift
@@ -45,14 +45,7 @@ extension TracerInstant {
 /// The primary purpose of this clock protocol is to enable mocking the "now" time when starting and ending spans,
 /// especially when the system is already using some notion of simulated or mocked time, such that traces are
 /// expressed using the same notion of time.
-public protocol TracerClock {
-    associatedtype Instant: TracerInstant
-
-    var now: Self.Instant { get }
-}
-
-/// A basic "timestamp clock" implementation that is able to five the current time as an unix timestamp.
-public struct DefaultTracerClock: TracerClock {
+public struct DefaultTracerClock {
     public typealias Instant = Timestamp
 
     public init() {

--- a/Tests/TracingTests/SpanTests.swift
+++ b/Tests/TracingTests/SpanTests.swift
@@ -28,7 +28,7 @@ final class SpanTests: XCTestCase {
         let clock = MockClock()
         clock.setTime(42_000_000)
 
-        let event = SpanEvent(name: "test", clock: clock)
+        let event = SpanEvent(name: "test", at: clock.now)
 
         XCTAssertEqual(event.name, "test")
         XCTAssertEqual(event.nanosecondsSinceEpoch, 42_000_000)

--- a/Tests/TracingTests/TracedLockTests.swift
+++ b/Tests/TracingTests/TracedLockTests.swift
@@ -60,18 +60,18 @@ enum TaskIDKey: BaggageKey {
 
 /// Only intended to be used in single-threaded testing.
 private final class TracedLockPrintlnTracer: LegacyTracer {
-    func startAnySpan<Clock: TracerClock>(
+    func startAnySpan<Instant: TracerInstant>(
         _ operationName: String,
         baggage: @autoclosure () -> Baggage,
         ofKind kind: SpanKind,
-        clock: Clock,
+        at instant: @autoclosure () -> Instant,
         function: String,
         file fileID: String,
         line: UInt
     ) -> any Span {
         TracedLockPrintlnSpan(
             operationName: operationName,
-            startTime: clock.now,
+            startTime: instant(),
             kind: kind,
             baggage: baggage()
         )
@@ -151,10 +151,10 @@ private final class TracedLockPrintlnTracer: LegacyTracer {
             self.events.append(event)
         }
 
-        func recordError(_ error: Error, attributes: SpanAttributes) {}
+        func recordError<Instant: TracerInstant>(_ error: Error, attributes: SpanAttributes, at instant: @autoclosure () -> Instant) {}
 
-        func end<Clock: TracerClock>(clock: Clock) {
-            let time = clock.now
+        func end<Instant: TracerInstant>(at instant: Instant) {
+            let time = instant
             self.endTimeMillis = time.millisecondsSinceEpoch
             print("     span [\(self.operationName): \(self.baggage[TaskIDKey.self] ?? "no-name")] @ \(time): end")
         }
@@ -163,18 +163,18 @@ private final class TracedLockPrintlnTracer: LegacyTracer {
 
 #if swift(>=5.7.0)
 extension TracedLockPrintlnTracer: Tracer {
-    func startSpan<Clock: TracerClock>(
+    func startSpan<Instant: TracerInstant>(
         _ operationName: String,
         baggage: @autoclosure () -> Baggage,
         ofKind kind: SpanKind,
-        clock: Clock,
+        at instant: @autoclosure () -> Instant,
         function: String,
         file fileID: String,
         line: UInt
     ) -> TracedLockPrintlnSpan {
         TracedLockPrintlnSpan(
             operationName: operationName,
-            startTime: clock.now,
+            startTime: instant(),
             kind: kind,
             baggage: baggage()
         )

--- a/Tests/TracingTests/TracerTests+swift57.swift
+++ b/Tests/TracingTests/TracerTests+swift57.swift
@@ -24,18 +24,18 @@ final class SampleSwift57Tracer: Tracer {
     private(set) var spans = [SampleSwift57Span]()
     var onEndSpan: (SampleSwift57Span) -> Void = { _ in }
 
-    func startSpan<Clock: TracerClock>(
+    func startSpan<Instant: TracerInstant>(
         _ operationName: String,
         baggage: @autoclosure () -> Baggage,
         ofKind kind: SpanKind,
-        clock: Clock,
+        at instant: @autoclosure () -> Instant,
         function: String,
         file fileID: String,
         line: UInt
     ) -> SampleSwift57Span {
         let span = SampleSwift57Span(
             operationName: operationName,
-            startTime: clock.now,
+            startTime: instant(),
             baggage: baggage(),
             kind: kind,
             onEnd: self.onEndSpan
@@ -65,8 +65,8 @@ final class SampleSwift57Span: Span {
 
     private var status: SpanStatus?
 
-    public let startTime: UInt64
-    public private(set) var endTime: UInt64?
+    public let startTimeNanoseconds: UInt64
+    public private(set) var endTimeNanoseconds: UInt64?
 
     private(set) var recordedErrors: [(Error, SpanAttributes)] = []
 
@@ -99,7 +99,7 @@ final class SampleSwift57Span: Span {
         onEnd: @escaping (SampleSwift57Span) -> Void
     ) {
         self.operationName = operationName
-        self.startTime = startTime.millisecondsSinceEpoch
+        self.startTimeNanoseconds = startTime.nanosecondsSinceEpoch
         self.baggage = baggage
         self.onEnd = onEnd
         self.kind = kind
@@ -118,12 +118,12 @@ final class SampleSwift57Span: Span {
         self.events.append(event)
     }
 
-    func recordError(_ error: Error, attributes: SpanAttributes) {
+    func recordError<Instant: TracerInstant>(_ error: Error, attributes: SpanAttributes, at instant: @autoclosure () -> Instant) {
         self.recordedErrors.append((error, attributes))
     }
 
-    func end<Clock: TracerClock>(clock: Clock) {
-        self.endTime = clock.now.millisecondsSinceEpoch
+    func end<Instant: TracerInstant>(at instant: Instant) {
+        self.endTimeNanoseconds = instant.nanosecondsSinceEpoch
         self.onEnd(self)
     }
 }

--- a/Tests/TracingTests/TracerTests.swift
+++ b/Tests/TracingTests/TracerTests.swift
@@ -357,12 +357,12 @@ final class TracerTests: XCTestCase {
 
         #if swift(>=5.7.0)
         tracer.withSpan("") { _ in }
-        tracer.withSpan("", clock: clock) { _ in }
+        tracer.withSpan("", at: clock.now) { _ in }
         tracer.withSpan("", baggage: .topLevel) { _ in }
         #endif
 
         tracer.withAnySpan("") { _ in }
-        tracer.withAnySpan("", clock: clock) { _ in }
+        tracer.withAnySpan("", at: clock.now) { _ in }
         tracer.withAnySpan("", baggage: .topLevel) { _ in }
     }
 

--- a/Tests/TracingTests/TracerTimeTests.swift
+++ b/Tests/TracingTests/TracerTimeTests.swift
@@ -43,16 +43,16 @@ final class TracerTimeTests: XCTestCase {
         let mockClock = MockClock()
         mockClock.setTime(13)
         #if swift(>=5.7.0)
-        let span: TestSpan = tracer.startSpan("start", clock: mockClock)
+        let span: TestSpan = tracer.startSpan("start", at: mockClock.now)
         XCTAssertEqual(span.startTimestampNanosSinceEpoch, 13)
         #else
-        let span: TestSpan = tracer.startAnySpan("start", clock: mockClock) as! TestSpan
+        let span: TestSpan = tracer.startAnySpan("start", at: mockClock.now) as! TestSpan
         XCTAssertEqual(span.startTimestampNanosSinceEpoch, 13)
         #endif
     }
 }
 
-final class MockClock: TracerClock {
+final class MockClock {
     var _now: UInt64 = 0
 
     init() {}


### PR DESCRIPTION
**Motivation:**

we don't need the clock protocol, but we do need the default clock to provide an instant.

We also add time to recordError in this PR

Resolves https://github.com/apple/swift-distributed-tracing/issues/119
Resolves https://github.com/apple/swift-distributed-tracing/issues/108