### PR TITLE
end() should take an autoclosure instant, not direct instant

### DIFF
--- a/Sources/Tracing/NoOpTracer.swift
+++ b/Sources/Tracing/NoOpTracer.swift
@@ -84,7 +84,7 @@ public struct NoOpTracer: LegacyTracer {
             }
         }
 
-        public func end<Instant: TracerInstant>(at instant: Instant) {
+        public func end<Instant: TracerInstant>(at instant: @autoclosure () -> Instant) {
             // ignore
         }
     }

--- a/Sources/Tracing/SpanProtocol.swift
+++ b/Sources/Tracing/SpanProtocol.swift
@@ -100,7 +100,7 @@ public protocol Span: _SwiftTracingSendableSpan {
     ///   - instant: the time instant at which the span ended
     ///
     /// - SeeAlso: `Span.end()` which automatically uses the "current" time.
-    func end<Instant: TracerInstant>(at instant: Instant)
+    func end<Instant: TracerInstant>(at instant: @autoclosure () -> Instant)
 }
 
 extension Span {

--- a/Tests/TracingTests/DynamicTracepointTracerTests.swift
+++ b/Tests/TracingTests/DynamicTracepointTracerTests.swift
@@ -322,8 +322,8 @@ extension DynamicTracepointTestTracer {
             // nothing
         }
 
-        func end<Instant: TracerInstant>(at instant: Instant) {
-            self.endTimestampNanosSinceEpoch = instant.nanosecondsSinceEpoch
+        func end<Instant: TracerInstant>(at instant: @autoclosure () -> Instant) {
+            self.endTimestampNanosSinceEpoch = instant().nanosecondsSinceEpoch
             self.onEnd(self)
         }
     }

--- a/Tests/TracingTests/TestTracer.swift
+++ b/Tests/TracingTests/TestTracer.swift
@@ -181,8 +181,8 @@ final class TestSpan: Span {
         self.recordedErrors.append((error, attributes))
     }
 
-    func end<Instant: TracerInstant>(at instant: Instant) {
-        self.endTimestampNanosSinceEpoch = instant.nanosecondsSinceEpoch
+    func end<Instant: TracerInstant>(at instant: @autoclosure () -> Instant) {
+        self.endTimestampNanosSinceEpoch = instant().nanosecondsSinceEpoch
         self.onEnd(self)
     }
 }

--- a/Tests/TracingTests/TracedLockTests.swift
+++ b/Tests/TracingTests/TracedLockTests.swift
@@ -153,8 +153,8 @@ private final class TracedLockPrintlnTracer: LegacyTracer {
 
         func recordError<Instant: TracerInstant>(_ error: Error, attributes: SpanAttributes, at instant: @autoclosure () -> Instant) {}
 
-        func end<Instant: TracerInstant>(at instant: Instant) {
-            let time = instant
+        func end<Instant: TracerInstant>(at instant: @autoclosure () -> Instant) {
+            let time = instant()
             self.endTimeMillis = time.millisecondsSinceEpoch
             print("     span [\(self.operationName): \(self.baggage[TaskIDKey.self] ?? "no-name")] @ \(time): end")
         }

--- a/Tests/TracingTests/TracerTests+swift57.swift
+++ b/Tests/TracingTests/TracerTests+swift57.swift
@@ -122,8 +122,8 @@ final class SampleSwift57Span: Span {
         self.recordedErrors.append((error, attributes))
     }
 
-    func end<Instant: TracerInstant>(at instant: Instant) {
-        self.endTimeNanoseconds = instant.nanosecondsSinceEpoch
+    func end<Instant: TracerInstant>(at instant: @autoclosure () -> Instant) {
+        self.endTimeNanoseconds = instant().nanosecondsSinceEpoch
         self.onEnd(self)
     }
 }


### PR DESCRIPTION
**Motivation:**

we want to avoid querying time if we don't have to

**Modifications:**

end() functions now take autoclosure () -> Instant allowing us to not query time unless we have to (e.g. are "recording")

Review followup from https://github.com/apple/swift-distributed-tracing/pull/120/files#r1165288201