### PR TITLE
update the otel-config to match latest otel image

### DIFF
--- a/Samples/Dinner/docker/collector-config.yaml
+++ b/Samples/Dinner/docker/collector-config.yaml
@@ -8,8 +8,8 @@ exporters:
   logging:
     verbosity: detailed
 
-  jaeger:
-    endpoint: "jaeger:14250"
+  otlp:
+    endpoint: jaeger:4317
     tls:
       insecure: true
 
@@ -21,4 +21,4 @@ service:
   pipelines:
     traces:
       receivers: otlp
-      exporters: [logging, jaeger, zipkin]
+      exporters: [logging, otlp, zipkin]


### PR DESCRIPTION
Found the existing configuration wasn't working with the latest otel docker image, and in digging, found that `jaeger` is no longer a valid exporter for otel-collector. Since Jaeger has an OTLP collector itself now directly available, this updates the 'jaeger' exporter to use `otlp` instead.

Kudos to
https://stackoverflow.com/questions/77475771/error-when-running-otel-collector-with-jaeger-in-docker-containers, which helped me identify the fix