### PR TITLE
Support compiling against Musl

### DIFF
--- a/IntegrationTests/allocation-counter-tests-framework/template/scaffolding.swift
+++ b/IntegrationTests/allocation-counter-tests-framework/template/scaffolding.swift
@@ -28,10 +28,14 @@
 
 import AtomicCounter
 import Foundation
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("Unsupported runtime")
 #endif
 
 func waitForThreadsToQuiesce(shouldReachZero: Bool) {

--- a/Sources/Instrumentation/Locks.swift
+++ b/Sources/Instrumentation/Locks.swift
@@ -26,10 +26,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("Unsupported runtime")
 #endif
 
 /// A threading lock based on `libpthread` instead of `libdispatch`.

--- a/Sources/Tracing/TracingTime.swift
+++ b/Sources/Tracing/TracingTime.swift
@@ -12,10 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux)
-import Glibc
-#else
+#if canImport(Darwin)
 import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("Unsupported runtime")
 #endif
 
 @_exported import Instrumentation


### PR DESCRIPTION
### Motivation

When building for Linux, we would like to be able to build this package on top of Musl, as well as the usual Glibc.

### Modifications

Replace imports of Glibc with conditional imports using the following pattern:

```diff
- import Glibc
+ #if canImport(Glibc)
+ import Glibc
+ #elseif canImport(Musl)
+ import Musl
+ #else
+ #error("Unsupported runtime")
+ #endif
```

### Result

Can compile against Musl.