### PR TITLE
Explicitly declare the ServiceContext dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,7 @@ let package = Package(
         .target(
             name: "Tracing",
             dependencies: [
+                .product(name: "ServiceContextModule", package: "swift-service-context"),
                 .target(name: "Instrumentation"),
             ]
         ),


### PR DESCRIPTION
In my project, every first clean build causes the next error.

```
/my_project/.build/checkouts/swift-distributed-tracing/Sources/Tracing/InstrumentationSystem+Tracing.swift:15:19: error: missing required module 'ServiceContextModule'
@_exported import Instrumentation
```
and this error does not appear when retrying the build.
In practice, this is caused by an implicit dependency through another target and the use of `@_exported`, so we need to declare the dependency explicitly.

- environment

```
# swift --version
Swift version 5.10 (swift-5.10-RELEASE)
Target: aarch64-unknown-linux-gnu
```