### PR TITLE
Adopt Swift 6.0 #isolation; Resolves async closure behavior in withSpan

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "Tracing", targets: ["Tracing"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-service-context.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-service-context.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/Tracing/Tracer.swift
+++ b/Sources/Tracing/Tracer.swift
@@ -322,7 +322,7 @@ public func withSpan<T>(
 ///   - operation: The operation that this span should be measuring
 /// - Returns: the value returned by `operation`
 /// - Throws: the error the `operation` has thrown (if any)
-#if swift(>=6.0.0)
+#if swift(>=6.0)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal ServiceContext
 public func withSpan<T, Instant: TracerInstant>(
     _ operationName: String,
@@ -347,7 +347,10 @@ public func withSpan<T, Instant: TracerInstant>(
         try await operation(anySpan)
     }
 }
-#else
+#endif
+
+@_disfavoredOverload
+@available(*, deprecated, message: "Prefer #isolation version of this API")
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal ServiceContext
 public func withSpan<T, Instant: TracerInstant>(
     _ operationName: String,
@@ -371,7 +374,6 @@ public func withSpan<T, Instant: TracerInstant>(
         try await operation(anySpan)
     }
 }
-#endif
 
 /// Start a new ``Span`` and automatically end when the `operation` completes,
 /// including recording the `error` in case the operation throws.
@@ -396,7 +398,7 @@ public func withSpan<T, Instant: TracerInstant>(
 ///   - operation: The operation that this span should be measuring
 /// - Returns: the value returned by `operation`
 /// - Throws: the error the `operation` has thrown (if any)
-#if swift(>=6.0.0)
+#if swift(>=6.0)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal ServiceContext
 public func withSpan<T>(
     _ operationName: String,
@@ -420,7 +422,10 @@ public func withSpan<T>(
         try await operation(anySpan)
     }
 }
-#else
+#endif
+
+@_disfavoredOverload
+@available(*, deprecated, message: "Prefer #isolation version of this API")
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal ServiceContext
 public func withSpan<T>(
     _ operationName: String,
@@ -443,7 +448,6 @@ public func withSpan<T>(
         try await operation(anySpan)
     }
 }
-#endif
 
 /// Start a new ``Span`` and automatically end when the `operation` completes,
 /// including recording the `error` in case the operation throws.
@@ -469,7 +473,7 @@ public func withSpan<T>(
 ///   - operation: The operation that this span should be measuring
 /// - Returns: the value returned by `operation`
 /// - Throws: the error the `operation` has thrown (if any)
-#if swift(>=6.0.0)
+#if swift(>=6.0)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public func withSpan<T>(
     _ operationName: String,
@@ -494,7 +498,10 @@ public func withSpan<T>(
         try await operation(anySpan)
     }
 }
-#else
+#endif
+
+@_disfavoredOverload
+@available(*, deprecated, message: "Prefer #isolation version of this API")
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public func withSpan<T>(
     _ operationName: String,
@@ -518,4 +525,3 @@ public func withSpan<T>(
         try await operation(anySpan)
     }
 }
-#endif

--- a/Sources/Tracing/Tracer.swift
+++ b/Sources/Tracing/Tracer.swift
@@ -329,7 +329,7 @@ public func withSpan<T, Instant: TracerInstant>(
     at instant: @autoclosure () -> Instant,
     context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
     ofKind kind: SpanKind = .internal,
-    isolation: isolated (any Actor)? = #isolation,
+    isolation: isolated(any Actor)? = #isolation,
     function: String = #function,
     file fileID: String = #fileID,
     line: UInt = #line,
@@ -350,26 +350,26 @@ public func withSpan<T, Instant: TracerInstant>(
 #else
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal ServiceContext
 public func withSpan<T, Instant: TracerInstant>(
-  _ operationName: String,
-  at instant: @autoclosure () -> Instant,
-  context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
-  ofKind kind: SpanKind = .internal,
-  function: String = #function,
-  file fileID: String = #fileID,
-  line: UInt = #line,
-  _ operation: (any Span) async throws -> T
+    _ operationName: String,
+    at instant: @autoclosure () -> Instant,
+    context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
+    ofKind kind: SpanKind = .internal,
+    function: String = #function,
+    file fileID: String = #fileID,
+    line: UInt = #line,
+    _ operation: (any Span) async throws -> T
 ) async rethrows -> T {
-  try await InstrumentationSystem.legacyTracer.withAnySpan(
-    operationName,
-    at: instant(),
-    context: context(),
-    ofKind: kind,
-    function: function,
-    file: fileID,
-    line: line
-  ) { anySpan in
-    try await operation(anySpan)
-  }
+    try await InstrumentationSystem.legacyTracer.withAnySpan(
+        operationName,
+        at: instant(),
+        context: context(),
+        ofKind: kind,
+        function: function,
+        file: fileID,
+        line: line
+    ) { anySpan in
+        try await operation(anySpan)
+    }
 }
 #endif
 
@@ -388,7 +388,7 @@ public func withSpan<T, Instant: TracerInstant>(
 /// - Parameters:
 ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
 ///   - context: The `ServiceContext` providing information on where to start the new ``Span``.
-///   - kind: The ``SpanKind`` of the new ``Span``.
+///   - ofKind: The ``SpanKind`` of the new ``Span``.
 ///   - isolation: Defaulted parameter for inheriting isolation of calling actor
 ///   - function: The function name in which the span was started
 ///   - fileID: The `fileID` where the span was started.
@@ -402,7 +402,7 @@ public func withSpan<T>(
     _ operationName: String,
     context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
     ofKind kind: SpanKind = .internal,
-    isolation: isolated (any Actor)? = #isolation,
+    isolation: isolated(any Actor)? = #isolation,
     function: String = #function,
     file fileID: String = #fileID,
     line: UInt = #line,
@@ -476,7 +476,7 @@ public func withSpan<T>(
     context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
     ofKind kind: SpanKind = .internal,
     at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
-    isolation: isolated (any Actor)? = #isolation,
+    isolation: isolated(any Actor)? = #isolation,
     function: String = #function,
     file fileID: String = #fileID,
     line: UInt = #line,

--- a/Sources/Tracing/TracerProtocol+Legacy.swift
+++ b/Sources/Tracing/TracerProtocol+Legacy.swift
@@ -300,12 +300,45 @@ extension LegacyTracer {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - context: The `ServiceContext` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - isolation: Defaulted parameter for inheriting isolation of calling actor
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
+  #if swift(>=6.0.0)
+    public func withAnySpan<T, Instant: TracerInstant>(
+        _ operationName: String,
+        at instant: @autoclosure () -> Instant,
+        context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
+        ofKind kind: SpanKind = .internal,
+        isolation: isolated (any Actor)? = #isolation,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        _ operation: (any Tracing.Span) async throws -> T
+    ) async rethrows -> T {
+        let span = self.startAnySpan(
+            operationName,
+            at: instant(),
+            context: context(),
+            ofKind: kind,
+            function: function,
+            file: fileID,
+            line: line
+        )
+        defer { span.end() }
+        do {
+            return try await ServiceContext.$current.withValue(span.context) {
+                try await operation(span)
+            }
+        } catch {
+            span.recordError(error)
+            throw error // rethrow
+        }
+    }
+  #else
     public func withAnySpan<T, Instant: TracerInstant>(
         _ operationName: String,
         at instant: @autoclosure () -> Instant,
@@ -335,6 +368,7 @@ extension LegacyTracer {
             throw error // rethrow
         }
     }
+  #endif
 
     /// Start a new ``Span`` and automatically end when the `operation` completes,
     /// including recording the `error` in case the operation throws.
@@ -354,12 +388,44 @@ extension LegacyTracer {
     ///   - operationName: The name of the operation being traced. This may be a handler function, database call, ...
     ///   - context: The `ServiceContext` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
+    ///   - isolation: Defaulted parameter for inheriting isolation of calling actor
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
+#if swift(>=6.0.0)
+    public func withAnySpan<T>(
+        _ operationName: String,
+        context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
+        ofKind kind: SpanKind = .internal,
+        isolation: (any Actor)? = #isolation,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        _ operation: (any Tracing.Span) async throws -> T
+    ) async rethrows -> T {
+        let span = self.startAnySpan(
+            operationName,
+            at: DefaultTracerClock.now,
+            context: context(),
+            ofKind: kind,
+            function: function,
+            file: fileID,
+            line: line
+        )
+        defer { span.end() }
+        do {
+            return try await ServiceContext.$current.withValue(span.context) {
+                try await operation(span)
+            }
+        } catch {
+            span.recordError(error)
+            throw error // rethrow
+        }
+    }
+#else
     public func withAnySpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -388,6 +454,7 @@ extension LegacyTracer {
             throw error // rethrow
         }
     }
+#endif
 }
 
 #if swift(>=5.7.0)
@@ -524,12 +591,38 @@ extension Tracer {
     ///   - context: The `ServiceContext` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
     ///   - instant: the time instant at which the span started
+    ///   - isolation: Defaulted parameter for inheriting isolation of calling actor
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
+#if swift(>=6.0.0)
+    public func withAnySpan<T>(
+        _ operationName: String,
+        at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
+        context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
+        ofKind kind: SpanKind = .internal,
+        isolation: (any Actor)? = #isolation,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        @_inheritActorContext @_implicitSelfCapture _ operation: (any Tracing.Span) async throws -> T
+    ) async rethrows -> T {
+        try await self.withSpan(
+            operationName,
+            context: context(),
+            ofKind: kind,
+            at: instant(),
+            function: function,
+            file: fileID,
+            line: line
+        ) { span in
+            try await operation(span)
+        }
+    }
+#else
     public func withAnySpan<T>(
         _ operationName: String,
         at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
@@ -552,5 +645,6 @@ extension Tracer {
             try await operation(span)
         }
     }
+#endif
 }
 #endif

--- a/Sources/Tracing/TracerProtocol+Legacy.swift
+++ b/Sources/Tracing/TracerProtocol+Legacy.swift
@@ -307,7 +307,7 @@ extension LegacyTracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-    #if swift(>=6.0.0)
+    #if swift(>=6.0)
     public func withAnySpan<T, Instant: TracerInstant>(
         _ operationName: String,
         at instant: @autoclosure () -> Instant,
@@ -338,7 +338,10 @@ extension LegacyTracer {
             throw error // rethrow
         }
     }
-    #else
+    #endif
+
+    @_disfavoredOverload
+    @available(*, deprecated, message: "Prefer #isolation version of this API")
     public func withAnySpan<T, Instant: TracerInstant>(
         _ operationName: String,
         at instant: @autoclosure () -> Instant,
@@ -368,7 +371,6 @@ extension LegacyTracer {
             throw error // rethrow
         }
     }
-    #endif
 
     /// Start a new ``Span`` and automatically end when the `operation` completes,
     /// including recording the `error` in case the operation throws.
@@ -395,7 +397,7 @@ extension LegacyTracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-    #if swift(>=6.0.0)
+    #if swift(>=6.0)
     public func withAnySpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -425,7 +427,10 @@ extension LegacyTracer {
             throw error // rethrow
         }
     }
-    #else
+    #endif
+
+    @_disfavoredOverload
+    @available(*, deprecated, message: "Prefer #isolation version of this API")
     public func withAnySpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -454,7 +459,6 @@ extension LegacyTracer {
             throw error // rethrow
         }
     }
-    #endif
 }
 
 #if swift(>=5.7.0)
@@ -598,7 +602,7 @@ extension Tracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-    #if swift(>=6.0.0)
+    #if swift(>=6.0)
     public func withAnySpan<T>(
         _ operationName: String,
         at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
@@ -622,7 +626,10 @@ extension Tracer {
             try await operation(span)
         }
     }
-    #else
+    #endif
+
+    @_disfavoredOverload
+    @available(*, deprecated, message: "Prefer #isolation version of this API")
     public func withAnySpan<T>(
         _ operationName: String,
         at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
@@ -645,6 +652,5 @@ extension Tracer {
             try await operation(span)
         }
     }
-    #endif
 }
 #endif

--- a/Sources/Tracing/TracerProtocol+Legacy.swift
+++ b/Sources/Tracing/TracerProtocol+Legacy.swift
@@ -307,13 +307,13 @@ extension LegacyTracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-  #if swift(>=6.0.0)
+    #if swift(>=6.0.0)
     public func withAnySpan<T, Instant: TracerInstant>(
         _ operationName: String,
         at instant: @autoclosure () -> Instant,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
         ofKind kind: SpanKind = .internal,
-        isolation: isolated (any Actor)? = #isolation,
+        isolation: isolated(any Actor)? = #isolation,
         function: String = #function,
         file fileID: String = #fileID,
         line: UInt = #line,
@@ -338,7 +338,7 @@ extension LegacyTracer {
             throw error // rethrow
         }
     }
-  #else
+    #else
     public func withAnySpan<T, Instant: TracerInstant>(
         _ operationName: String,
         at instant: @autoclosure () -> Instant,
@@ -368,7 +368,7 @@ extension LegacyTracer {
             throw error // rethrow
         }
     }
-  #endif
+    #endif
 
     /// Start a new ``Span`` and automatically end when the `operation` completes,
     /// including recording the `error` in case the operation throws.
@@ -395,7 +395,7 @@ extension LegacyTracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-#if swift(>=6.0.0)
+    #if swift(>=6.0.0)
     public func withAnySpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -425,7 +425,7 @@ extension LegacyTracer {
             throw error // rethrow
         }
     }
-#else
+    #else
     public func withAnySpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -454,7 +454,7 @@ extension LegacyTracer {
             throw error // rethrow
         }
     }
-#endif
+    #endif
 }
 
 #if swift(>=5.7.0)
@@ -598,7 +598,7 @@ extension Tracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-#if swift(>=6.0.0)
+    #if swift(>=6.0.0)
     public func withAnySpan<T>(
         _ operationName: String,
         at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
@@ -622,7 +622,7 @@ extension Tracer {
             try await operation(span)
         }
     }
-#else
+    #else
     public func withAnySpan<T>(
         _ operationName: String,
         at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
@@ -645,6 +645,6 @@ extension Tracer {
             try await operation(span)
         }
     }
-#endif
+    #endif
 }
 #endif

--- a/Sources/Tracing/TracerProtocol.swift
+++ b/Sources/Tracing/TracerProtocol.swift
@@ -235,12 +235,44 @@ extension Tracer {
     ///   - context: The `ServiceContext` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
     ///   - instant: the time instant at which the span started
+    ///   - isolation: Defaulted parameter for inheriting isolation of calling actor
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
+#if swift(>=6.0.0)
+    public func withSpan<T>(
+        _ operationName: String,
+        context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
+        ofKind kind: SpanKind = .internal,
+        isolation: (any Actor)? = #isolation,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        @_inheritActorContext @_implicitSelfCapture _ operation: (Self.Span) async throws -> T
+    ) async rethrows -> T {
+        let span = self.startSpan(
+            operationName,
+            context: context(),
+            ofKind: kind,
+            at: DefaultTracerClock.now,
+            function: function,
+            file: fileID,
+            line: line
+        )
+        defer { span.end() }
+        do {
+            return try await ServiceContext.$current.withValue(span.context) {
+                try await operation(span)
+            }
+        } catch {
+            span.recordError(error)
+            throw error // rethrow
+        }
+    }
+#else
     public func withSpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -269,6 +301,7 @@ extension Tracer {
             throw error // rethrow
         }
     }
+#endif
 
     /// Start a new ``Span`` and automatically end when the `operation` completes,
     /// including recording the `error` in case the operation throws.
@@ -287,12 +320,45 @@ extension Tracer {
     ///   - context: The `ServiceContext` providing information on where to start the new ``Span``.
     ///   - kind: The ``SpanKind`` of the new ``Span``.
     ///   - instant: the time instant at which the span started
+    ///   - isolation: Defaulted parameter for inheriting isolation of calling actor
     ///   - function: The function name in which the span was started
     ///   - fileID: The `fileID` where the span was started.
     ///   - line: The file line where the span was started.
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
+#if swift(>=6.0.0)
+    public func withSpan<T>(
+        _ operationName: String,
+        context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
+        ofKind kind: SpanKind = .internal,
+        at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,
+        isolation: (any Actor)? = #isolation,
+        function: String = #function,
+        file fileID: String = #fileID,
+        line: UInt = #line,
+        @_inheritActorContext @_implicitSelfCapture _ operation: (Self.Span) async throws -> T
+    ) async rethrows -> T {
+        let span = self.startSpan(
+            operationName,
+            context: context(),
+            ofKind: kind,
+            at: instant(),
+            function: function,
+            file: fileID,
+            line: line
+        )
+        defer { span.end() }
+        do {
+            return try await ServiceContext.$current.withValue(span.context) {
+                try await operation(span)
+            }
+        } catch {
+            span.recordError(error)
+            throw error // rethrow
+        }
+    }
+#else
     public func withSpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -322,4 +388,5 @@ extension Tracer {
             throw error // rethrow
         }
     }
+#endif
 }

--- a/Sources/Tracing/TracerProtocol.swift
+++ b/Sources/Tracing/TracerProtocol.swift
@@ -242,7 +242,7 @@ extension Tracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-#if swift(>=6.0.0)
+    #if swift(>=6.0.0)
     public func withSpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -272,7 +272,7 @@ extension Tracer {
             throw error // rethrow
         }
     }
-#else
+    #else
     public func withSpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -301,7 +301,7 @@ extension Tracer {
             throw error // rethrow
         }
     }
-#endif
+    #endif
 
     /// Start a new ``Span`` and automatically end when the `operation` completes,
     /// including recording the `error` in case the operation throws.
@@ -327,7 +327,7 @@ extension Tracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-#if swift(>=6.0.0)
+    #if swift(>=6.0.0)
     public func withSpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -358,7 +358,7 @@ extension Tracer {
             throw error // rethrow
         }
     }
-#else
+    #else
     public func withSpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -388,5 +388,5 @@ extension Tracer {
             throw error // rethrow
         }
     }
-#endif
+    #endif
 }

--- a/Tests/TracingTests/ActorTracingTests.swift
+++ b/Tests/TracingTests/ActorTracingTests.swift
@@ -22,6 +22,8 @@ final class ActorTracingTests: XCTestCase {
         super.tearDown()
         InstrumentationSystem.bootstrapInternal(nil)
     }
+
+    func test() {}
 }
 
 func work() async {}


### PR DESCRIPTION
**Motivation:**

This has been a problem for a long time, where we could not safely non sendable actor state from withSpan because the closure would "hop off". Now with #isolation we can handle it properly in Swift 6.0

**Modifications:**
Adopt #isolation parameter in all with... APIs with async closures.

**Result:**

Usages like this will not warn nor produce errors anymore:

```
actor Foo {
    var bar = 0

    func foo() async {
        var num = 0
         await withSpan(#function) { _ in
            // await self.withSpanWorkaround(#function) { _ in
            self.bar += 1
            await work()
            num += 1
        }
    }
}
```

resolves rdar://113848512