### PR TITLE
Fix use of Swift 6 language mode

### DIFF
--- a/Sources/Tracing/Tracer.swift
+++ b/Sources/Tracing/Tracer.swift
@@ -322,7 +322,7 @@ public func withSpan<T>(
 ///   - operation: The operation that this span should be measuring
 /// - Returns: the value returned by `operation`
 /// - Throws: the error the `operation` has thrown (if any)
-#if swift(>=6.0)
+#if compiler(>=6.0)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal ServiceContext
 public func withSpan<T, Instant: TracerInstant>(
     _ operationName: String,
@@ -398,7 +398,7 @@ public func withSpan<T, Instant: TracerInstant>(
 ///   - operation: The operation that this span should be measuring
 /// - Returns: the value returned by `operation`
 /// - Throws: the error the `operation` has thrown (if any)
-#if swift(>=6.0)
+#if compiler(>=6.0)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal ServiceContext
 public func withSpan<T>(
     _ operationName: String,
@@ -473,7 +473,7 @@ public func withSpan<T>(
 ///   - operation: The operation that this span should be measuring
 /// - Returns: the value returned by `operation`
 /// - Throws: the error the `operation` has thrown (if any)
-#if swift(>=6.0)
+#if compiler(>=6.0)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public func withSpan<T>(
     _ operationName: String,

--- a/Sources/Tracing/Tracer.swift
+++ b/Sources/Tracing/Tracer.swift
@@ -349,8 +349,10 @@ public func withSpan<T, Instant: TracerInstant>(
 }
 #endif
 
+#if compiler(>=6.0)
 @_disfavoredOverload
 @available(*, deprecated, message: "Prefer #isolation version of this API")
+#endif
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal ServiceContext
 public func withSpan<T, Instant: TracerInstant>(
     _ operationName: String,
@@ -424,8 +426,10 @@ public func withSpan<T>(
 }
 #endif
 
+#if compiler(>=6.0)
 @_disfavoredOverload
 @available(*, deprecated, message: "Prefer #isolation version of this API")
+#endif
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal ServiceContext
 public func withSpan<T>(
     _ operationName: String,
@@ -500,8 +504,10 @@ public func withSpan<T>(
 }
 #endif
 
+#if compiler(>=6.0)
 @_disfavoredOverload
 @available(*, deprecated, message: "Prefer #isolation version of this API")
+#endif
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public func withSpan<T>(
     _ operationName: String,

--- a/Sources/Tracing/TracerProtocol+Legacy.swift
+++ b/Sources/Tracing/TracerProtocol+Legacy.swift
@@ -340,8 +340,10 @@ extension LegacyTracer {
     }
     #endif
 
+    #if compiler(>=6.0)
     @_disfavoredOverload
     @available(*, deprecated, message: "Prefer #isolation version of this API")
+    #endif
     public func withAnySpan<T, Instant: TracerInstant>(
         _ operationName: String,
         at instant: @autoclosure () -> Instant,
@@ -429,8 +431,10 @@ extension LegacyTracer {
     }
     #endif
 
+    #if compiler(>=6.0)
     @_disfavoredOverload
     @available(*, deprecated, message: "Prefer #isolation version of this API")
+    #endif
     public func withAnySpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -628,8 +632,10 @@ extension Tracer {
     }
     #endif
 
+    #if compiler(>=6.0)
     @_disfavoredOverload
     @available(*, deprecated, message: "Prefer #isolation version of this API")
+    #endif
     public func withAnySpan<T>(
         _ operationName: String,
         at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,

--- a/Sources/Tracing/TracerProtocol+Legacy.swift
+++ b/Sources/Tracing/TracerProtocol+Legacy.swift
@@ -307,7 +307,7 @@ extension LegacyTracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-    #if swift(>=6.0)
+    #if compiler(>=6.0)
     public func withAnySpan<T, Instant: TracerInstant>(
         _ operationName: String,
         at instant: @autoclosure () -> Instant,
@@ -397,7 +397,7 @@ extension LegacyTracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-    #if swift(>=6.0)
+    #if compiler(>=6.0)
     public func withAnySpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -602,7 +602,7 @@ extension Tracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-    #if swift(>=6.0)
+    #if compiler(>=6.0)
     public func withAnySpan<T>(
         _ operationName: String,
         at instant: @autoclosure () -> some TracerInstant = DefaultTracerClock.now,

--- a/Sources/Tracing/TracerProtocol.swift
+++ b/Sources/Tracing/TracerProtocol.swift
@@ -274,8 +274,10 @@ extension Tracer {
     }
     #endif
 
+    #if compiler(>=6.0)
     @_disfavoredOverload
     @available(*, deprecated, message: "Prefer #isolation version of this API")
+    #endif
     public func withSpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -362,8 +364,10 @@ extension Tracer {
     }
     #endif
 
+    #if compiler(>=6.0)
     @_disfavoredOverload
     @available(*, deprecated, message: "Prefer #isolation version of this API")
+    #endif
     public func withSpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,

--- a/Sources/Tracing/TracerProtocol.swift
+++ b/Sources/Tracing/TracerProtocol.swift
@@ -242,7 +242,7 @@ extension Tracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-    #if swift(>=6.0)
+    #if compiler(>=6.0)
     public func withSpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
@@ -329,7 +329,7 @@ extension Tracer {
     ///   - operation: The operation that this span should be measuring
     /// - Returns: the value returned by `operation`
     /// - Throws: the error the `operation` has thrown (if any)
-    #if swift(>=6.0)
+    #if compiler(>=6.0)
     public func withSpan<T>(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext = .current ?? .topLevel,


### PR DESCRIPTION
Adds a Package@swift-6.0.swift to make sure the package is compiled for the Swift 6 language mode. This fixes the visibility of the new withSpan functions, gated by `#if swift(>=6.0)`.

Not sure if this is the desired solution, but it currently works for us. Let me know if something else is required and I'll be happy to look into it.

Edit:
After digging in some more, I think it would be better to update all `#if swift(>=6.0)` conditionals to `#if compiler(>=6.0)`. Would that be an acceptable solution?