### PR TITLE
Add a TracingMacros module providing the @Traced macro

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,6 @@
 // swift-tools-version:5.9
-import PackageDescription
 import CompilerPluginSupport
+import PackageDescription
 
 let package = Package(
     name: "swift-distributed-tracing",

--- a/Package.swift
+++ b/Package.swift
@@ -1,14 +1,24 @@
 // swift-tools-version:5.9
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
     name: "swift-distributed-tracing",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+        .macCatalyst(.v13),
+    ],
     products: [
         .library(name: "Instrumentation", targets: ["Instrumentation"]),
         .library(name: "Tracing", targets: ["Tracing"]),
+        .library(name: "TracingMacros", targets: ["TracingMacros"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-service-context.git", from: "1.1.0")
+        .package(url: "https://github.com/apple/swift-service-context.git", from: "1.1.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0-latest"),
     ],
     targets: [
         // ==== --------------------------------------------------------------------------------------------------------
@@ -41,6 +51,33 @@ let package = Package(
             name: "TracingTests",
             dependencies: [
                 .target(name: "Tracing")
+            ]
+        ),
+
+        // ==== --------------------------------------------------------------------------------------------------------
+        // MARK: TracingMacros
+
+        .target(
+            name: "TracingMacros",
+            dependencies: [
+                .target(name: "Tracing"),
+                .target(name: "TracingMacrosImplementation"),
+            ]
+        ),
+        .macro(
+            name: "TracingMacrosImplementation",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+            ]
+        ),
+        .testTarget(
+            name: "TracingMacrosTests",
+            dependencies: [
+                .target(name: "Tracing"),
+                .target(name: "TracingMacros"),
+                .target(name: "TracingMacrosImplementation"),
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
             ]
         ),
     ]

--- a/Sources/TracingMacros/Docs.docc/TracedOperationName.md
+++ b/Sources/TracingMacros/Docs.docc/TracedOperationName.md
@@ -1,0 +1,38 @@
+# ``TracingMacros/TracedOperationName``
+
+### Examples
+
+The default behavior is to use the base name of the function, but you can
+explicitly specify this as well. This creates a span named `"preheatOven"`:
+```swift
+@Traced(.baseName)
+func preheatOven(temperature: Int)
+```
+
+You can request the full name of the function as the span name, this
+creates a span named `"preheatOven(temperature:)"`:
+```swift
+@Traced(.fullName)
+func preheatOven(temperature: Int)
+```
+
+And it is also initializable with a string literal for fully custom names,
+this creates a span explicitly named `"preheat oven"`:
+```swift
+@Traced("preheat oven")
+func preheatOven(temperature: Int)
+```
+And if you need to load an existing string value as a name, you can use
+`.string(someString)` to adapt it.
+
+
+## Topics
+
+### Create Operation Names
+- ``baseName``
+- ``fullName``
+- ``string(_:)``
+- ``init(stringLiteral:)``
+
+### Convert an Operation Name to a String
+- ``operationName(baseName:fullName:)``

--- a/Sources/TracingMacros/Docs.docc/index.md
+++ b/Sources/TracingMacros/Docs.docc/index.md
@@ -1,0 +1,19 @@
+# ``TracingMacros``
+
+Macro helpers for Tracing.
+
+## Overview
+
+The TracingMacros module provides optional macros to make it easier to write traced code.
+
+The ``Traced(_:context:ofKind:span:)`` macro lets you avoid the extra indentation that comes with
+adopting traced code, and avoids having to keep the throws/try and async/await
+in-sync with the body. You can just attach `@Traced` to a function and get
+started.
+
+## Topics
+
+### Tracing functions
+- ``Traced(_:context:ofKind:span:)``
+- ``TracedOperationName``
+

--- a/Sources/TracingMacros/TracedMacro.swift
+++ b/Sources/TracingMacros/TracedMacro.swift
@@ -15,11 +15,26 @@
 import Tracing
 
 #if compiler(>=6.0)
+/// Instrument a function to place the entire body inside a span.
+///
+/// This macro is equivalent to calling ``/Tracing/withSpan`` in the body, but saves an
+/// indentation level and duplication. It introduces a `span` variable into the
+/// body of the function which can be used to add attributes to the span.
+///
+/// Parameters are passed directly to ``/Tracing/withSpan`` where applicable,
+/// and omitting the parameters from the macro omit them from the call, falling
+/// back to the default.
+///
+/// - Parameters:
+///   - operationName: The name of the operation being traced. Defaults to the name of the function.
+///   - context: The `ServiceContext` providing information on where to start the new ``/Tracing/Span``.
+///   - kind: The ``/Tracing/SpanKind`` of the new ``/Tracing/Span``.
+///   - spanName: The name of the span variable to introduce in the function. Pass `"_"` to omit it.
 @attached(body)
 public macro Traced(
     _ operationName: String? = nil,
     context: ServiceContext? = nil,
     ofKind kind: SpanKind? = nil,
-    span spanName: String? = nil
+    span spanName: String = "span"
 ) = #externalMacro(module: "TracingMacrosImplementation", type: "TracedMacro")
 #endif

--- a/Sources/TracingMacros/TracedMacro.swift
+++ b/Sources/TracingMacros/TracedMacro.swift
@@ -14,25 +14,82 @@
 @_exported import ServiceContextModule
 import Tracing
 
+/// A span name for a traced operation, either derived from the function name or explicitly specified.
+///
+/// When using the ``Traced(_:context:ofKind:span:)`` macro, you can use this to customize the span name.
+public struct TracedOperationName: ExpressibleByStringLiteral {
+    @usableFromInline
+    let value: Name
+
+    @usableFromInline
+    enum Name {
+        case baseName
+        case fullName
+        case string(String)
+    }
+
+    internal init(value: Name) {
+        self.value = value
+    }
+
+    /// Use a literal string as an operation name.
+    public init(stringLiteral: String) {
+        value = .string(stringLiteral)
+    }
+
+    /// Use the base name of the attached function.
+    ///
+    /// For `func preheatOven(temperature: Int)` this is `"preheatOven"`.
+    public static let baseName = TracedOperationName(value: .baseName)
+
+    /// Use the full name of the attached function.
+    ///
+    /// For `func preheatOven(temperature: Int)` this is `"preheatOven(temperature:)"`.
+    /// This is provided by the `#function` macro.
+    public static let fullName = TracedOperationName(value: .fullName)
+
+    /// Use an explicitly specified operation name.
+    public static func string(_ text: String) -> Self {
+        .init(value: .string(text))
+    }
+
+    /// Helper logic to support the `Traced` macro turning this operation name into a string.
+    /// Provided as an inference guide.
+    ///
+    /// - Parameters:
+    ///   - baseName: The value to use for the ``baseName`` case. Must be
+    ///     specified explicitly because there's no equivalent of `#function`.
+    ///   - fullName: The value to use for the ``fullName`` case.
+    @inlinable
+    @_documentation(visibility: internal)
+    public static func _getOperationName(_ name: Self, baseName: String, fullName: String = #function) -> String {
+        switch name.value {
+        case .baseName: baseName
+        case .fullName: fullName
+        case let .string(text): text
+        }
+    }
+}
+
 #if compiler(>=6.0)
 /// Instrument a function to place the entire body inside a span.
 ///
-/// This macro is equivalent to calling ``/Tracing/withSpan`` in the body, but saves an
+/// This macro is equivalent to calling ``withSpan`` in the body, but saves an
 /// indentation level and duplication. It introduces a `span` variable into the
 /// body of the function which can be used to add attributes to the span.
 ///
-/// Parameters are passed directly to ``/Tracing/withSpan`` where applicable,
+/// Parameters are passed directly to ``withSpan`` where applicable,
 /// and omitting the parameters from the macro omit them from the call, falling
 /// back to the default.
 ///
 /// - Parameters:
-///   - operationName: The name of the operation being traced. Defaults to the name of the function.
-///   - context: The `ServiceContext` providing information on where to start the new ``/Tracing/Span``.
-///   - kind: The ``/Tracing/SpanKind`` of the new ``/Tracing/Span``.
+///   - operationName: The name of the operation being traced.
+///   - context: The `ServiceContext` providing information on where to start the new ``Span``.
+///   - kind: The ``SpanKind`` of the new ``Span``.
 ///   - spanName: The name of the span variable to introduce in the function. Pass `"_"` to omit it.
 @attached(body)
 public macro Traced(
-    _ operationName: String? = nil,
+    _ operationName: TracedOperationName = .baseName,
     context: ServiceContext? = nil,
     ofKind kind: SpanKind? = nil,
     span spanName: String = "span"

--- a/Sources/TracingMacros/TracedMacro.swift
+++ b/Sources/TracingMacros/TracedMacro.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Tracing open source project
+//
+// Copyright (c) 2020-2024 Apple Inc. and the Swift Distributed Tracing project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Distributed Tracing project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+@_exported import ServiceContextModule
+import Tracing
+
+#if compiler(>=6.0)
+@attached(body)
+public macro Traced(
+    _ operationName: String? = nil,
+    context: ServiceContext? = nil,
+    ofKind kind: SpanKind? = nil,
+    span spanName: String? = nil
+) = #externalMacro(module: "TracingMacrosImplementation", type: "TracedMacro")
+#endif

--- a/Sources/TracingMacrosImplementation/TracedMacro.swift
+++ b/Sources/TracingMacrosImplementation/TracedMacro.swift
@@ -24,7 +24,7 @@ public struct TracedMacro: BodyMacro {
         in context: some MacroExpansionContext
     ) throws -> [CodeBlockItemSyntax] {
         guard let function = declaration.as(FunctionDeclSyntax.self),
-              let body = function.body
+            let body = function.body
         else {
             throw MacroExpansionErrorMessage("expected a function with a body")
         }
@@ -33,10 +33,14 @@ public struct TracedMacro: BodyMacro {
         let (operationName, context, kind, spanName) = try extractArguments(from: node)
 
         var withSpanCall = FunctionCallExprSyntax("withSpan()" as ExprSyntax)!
-        withSpanCall.arguments.append(LabeledExprSyntax(
-            expression: operationName ?? ExprSyntax(StringLiteralExprSyntax(content: function.name.text))))
+        withSpanCall.arguments.append(
+            LabeledExprSyntax(
+                expression: operationName ?? ExprSyntax(StringLiteralExprSyntax(content: function.name.text))
+            )
+        )
         func appendComma() {
-            withSpanCall.arguments[withSpanCall.arguments.index(before: withSpanCall.arguments.endIndex)].trailingComma = .commaToken()
+            withSpanCall.arguments[withSpanCall.arguments.index(before: withSpanCall.arguments.endIndex)]
+                .trailingComma = .commaToken()
         }
         if let context {
             appendComma()
@@ -66,8 +70,8 @@ public struct TracedMacro: BodyMacro {
             throwsClause?.throwsSpecifier = .keyword(.throws)
         }
         var withSpanExpr: ExprSyntax = """
-        \(withSpanCall) { \(spanIdentifier) \(asyncClause)\(throwsClause)\(returnClause)in \(body.statements) }
-        """
+            \(withSpanCall) { \(spanIdentifier) \(asyncClause)\(throwsClause)\(returnClause)in \(body.statements) }
+            """
 
         // Apply a try / await as necessary to adapt the withSpan expression
 
@@ -111,9 +115,9 @@ public struct TracedMacro: BodyMacro {
         let spanNameExpr = getArgument(label: "span")
         if let spanNameExpr {
             guard let stringLiteral = spanNameExpr.as(StringLiteralExprSyntax.self),
-                  stringLiteral.segments.count == 1,
-                  let segment = stringLiteral.segments.first,
-                  let segmentText = segment.as(StringSegmentSyntax.self)
+                stringLiteral.segments.count == 1,
+                let segment = stringLiteral.segments.first,
+                let segmentText = segment.as(StringSegmentSyntax.self)
             else {
                 throw MacroExpansionErrorMessage("span name must be a simple string literal")
             }
@@ -138,11 +142,11 @@ public struct TracedMacro: BodyMacro {
 
 @main
 struct TracingMacroPlugin: CompilerPlugin {
-#if compiler(>=6.0)
+    #if compiler(>=6.0)
     let providingMacros: [Macro.Type] = [
-        TracedMacro.self,
+        TracedMacro.self
     ]
-#else
+    #else
     let providingMacros: [Macro.Type] = []
-#endif
+    #endif
 }

--- a/Sources/TracingMacrosImplementation/TracedMacro.swift
+++ b/Sources/TracingMacrosImplementation/TracedMacro.swift
@@ -129,7 +129,7 @@ public struct TracedMacro: BodyMacro {
             operationName: operationName,
             context: context,
             kind: kind,
-            spanName: spanName,
+            spanName: spanName
         )
     }
 

--- a/Sources/TracingMacrosImplementation/TracedMacro.swift
+++ b/Sources/TracingMacrosImplementation/TracedMacro.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Tracing open source project
+//
+// Copyright (c) 2020-2024 Apple Inc. and the Swift Distributed Tracing project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Distributed Tracing project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+#if compiler(>=6.0)
+public struct TracedMacro: BodyMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingBodyFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [CodeBlockItemSyntax] {
+        guard let function = declaration.as(FunctionDeclSyntax.self),
+              let body = function.body
+        else {
+            throw MacroExpansionErrorMessage("expected a function with a body")
+        }
+
+        let operationName = StringLiteralExprSyntax(content: function.name.text)
+        let withSpanCall: ExprSyntax = "withSpan(\(operationName))"
+        let withSpanExpr: ExprSyntax = "\(withSpanCall) { span in \(body.statements) }"
+
+        return ["\(withSpanExpr)"]
+    }
+}
+#endif
+
+@main
+struct TracingMacroPlugin: CompilerPlugin {
+#if compiler(>=6.0)
+    let providingMacros: [Macro.Type] = [
+        TracedMacro.self,
+    ]
+#else
+    let providingMacros: [Macro.Type] = []
+#endif
+}

--- a/Tests/TracingMacrosTests/TracedTests.swift
+++ b/Tests/TracingMacrosTests/TracedTests.swift
@@ -56,6 +56,146 @@ final class TracedMacroTests: XCTestCase {
         )
     }
 
+    func test_tracedMacro_sync_throws() {
+        assertMacroExpansion(
+            """
+            @Traced
+            func syncThrowingExample(param: Int) throws {
+                struct ExampleError: Error {
+                }
+                throw ExampleError()
+            }
+            """,
+            expandedSource: """
+            func syncThrowingExample(param: Int) throws {
+                try withSpan("syncThrowingExample") { span throws in
+                    struct ExampleError: Error {
+                    }
+                    throw ExampleError()
+                }
+            }
+            """,
+            macros: ["Traced": TracedMacro.self]
+        )
+    }
+
+    func test_tracedMacro_sync_rethrows() {
+        assertMacroExpansion(
+            """
+            @Traced
+            func syncRethrowingExample(body: () throws -> Int) rethrows -> Int {
+                print("Starting")
+                let result = try body()
+                print("Ending")
+                return result
+            }
+            """,
+            expandedSource: """
+            func syncRethrowingExample(body: () throws -> Int) rethrows -> Int {
+                try withSpan("syncRethrowingExample") { span throws -> Int in
+                    print("Starting")
+                    let result = try body()
+                    print("Ending")
+                    return result
+                }
+            }
+            """,
+            macros: ["Traced": TracedMacro.self]
+        )
+    }
+
+    func test_tracedMacro_async_nothrow() {
+        assertMacroExpansion(
+            """
+            @Traced
+            func asyncNonthrowingExample(param: Int) async {
+                print(param)
+            }
+            """,
+            expandedSource: """
+            func asyncNonthrowingExample(param: Int) async {
+                await withSpan("asyncNonthrowingExample") { span async in
+                    print(param)
+                }
+            }
+            """,
+            macros: ["Traced": TracedMacro.self]
+        )
+    }
+
+    func test_tracedMacro_async_throws() {
+        assertMacroExpansion(
+            """
+            @Traced
+            func asyncThrowingExample(param: Int) async throws {
+                try await Task.sleep(for: .seconds(1))
+                print("Hello")
+            }
+            """,
+            expandedSource: """
+            func asyncThrowingExample(param: Int) async throws {
+                try await withSpan("asyncThrowingExample") { span async throws in
+                    try await Task.sleep(for: .seconds(1))
+                    print("Hello")
+                }
+            }
+            """,
+            macros: ["Traced": TracedMacro.self]
+        )
+    }
+
+    func test_tracedMacro_async_rethrows() {
+        assertMacroExpansion(
+            """
+            @Traced
+            func asyncRethrowingExample(body: () async throws -> Int) async rethrows -> Int {
+                try? await Task.sleep(for: .seconds(1))
+                let result = try await body()
+                span.attributes["result"] = result
+                return result
+            }
+            """,
+            expandedSource: """
+            func asyncRethrowingExample(body: () async throws -> Int) async rethrows -> Int {
+                try await withSpan("asyncRethrowingExample") { span async throws -> Int in
+                    try? await Task.sleep(for: .seconds(1))
+                    let result = try await body()
+                    span.attributes["result"] = result
+                    return result
+                }
+            }
+            """,
+            macros: ["Traced": TracedMacro.self]
+        )
+    }
+
+    // Testing that this expands correctly, but not including this as a
+    // compile-test because withSpan doesn't currently support typed throws.
+    func test_tracedMacro_async_typed_throws() {
+        assertMacroExpansion(
+            """
+            @Traced
+            func asyncTypedThrowingExample<Err>(body: () async throws(Err) -> Int) async throws(Err) -> Int {
+                try? await Task.sleep(for: .seconds(1))
+                let result = try await body()
+                span.attributes["result"] = result
+                return result
+            }
+            """,
+            expandedSource: """
+            func asyncTypedThrowingExample<Err>(body: () async throws(Err) -> Int) async throws(Err) -> Int {
+                try await withSpan("asyncTypedThrowingExample") { span async throws(Err) -> Int in
+                    try? await Task.sleep(for: .seconds(1))
+                    let result = try await body()
+                    span.attributes["result"] = result
+                    return result
+                }
+            }
+            """,
+            macros: ["Traced": TracedMacro.self]
+        )
+    }
+
     func test_tracedMacro_accessSpan() {
         assertMacroExpansion(
             """
@@ -81,6 +221,39 @@ final class TracedMacroTests: XCTestCase {
 @Traced
 func syncNonthrowingExample(param: Int) {
     print(param)
+}
+
+@Traced
+func syncThrowingExample(param: Int) throws {
+    struct ExampleError: Error {}
+    throw ExampleError()
+}
+
+@Traced
+func syncRethrowingExample(body: () throws -> Int) rethrows -> Int {
+    print("Starting")
+    let result = try body()
+    print("Ending")
+    return result
+}
+
+@Traced
+func asyncNonthrowingExample(param: Int) async {
+    print(param)
+}
+
+@Traced
+func asyncThrowingExample(param: Int) async throws {
+    try await Task.sleep(for: .seconds(1))
+    print("Hello")
+}
+
+@Traced
+func asyncRethrowingExample(body: () async throws -> Int) async rethrows -> Int {
+    try? await Task.sleep(for: .seconds(1))
+    let result = try await body()
+    span.attributes["result"] = result
+    return result
 }
 
 @Traced

--- a/Tests/TracingMacrosTests/TracedTests.swift
+++ b/Tests/TracingMacrosTests/TracedTests.swift
@@ -1,7 +1,3 @@
-import SwiftSyntaxMacrosTestSupport
-import Tracing
-import TracingMacros
-import TracingMacrosImplementation
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Distributed Tracing open source project
@@ -15,6 +11,11 @@ import TracingMacrosImplementation
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+import SwiftSyntaxMacrosTestSupport
+import Tracing
+import TracingMacros
+import TracingMacrosImplementation
 import XCTest
 
 #if compiler(>=6.0)

--- a/Tests/TracingMacrosTests/TracedTests.swift
+++ b/Tests/TracingMacrosTests/TracedTests.swift
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Tracing open source project
+//
+// Copyright (c) 2020-2024 Apple Inc. and the Swift Distributed Tracing project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Distributed Tracing project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import SwiftSyntaxMacrosTestSupport
+
+import Tracing
+import TracingMacros
+import TracingMacrosImplementation
+
+#if compiler(>=6.0)
+
+final class TracedMacroTests: XCTestCase {
+    func test_tracedMacro_requires_body() {
+        assertMacroExpansion(
+            """
+            @Traced
+            func funcWithoutBody()
+            """,
+            expandedSource: """
+            func funcWithoutBody()
+            """,
+            diagnostics: [
+                .init(message: "expected a function with a body", line: 1, column: 1),
+            ],
+            macros: ["Traced": TracedMacro.self]
+        )
+    }
+
+    func test_tracedMacro_sync_nothrow() {
+        assertMacroExpansion(
+            """
+            @Traced
+            func syncNonthrowingExample(param: Int) {
+                print(param)
+            }
+            """,
+            expandedSource: """
+            func syncNonthrowingExample(param: Int) {
+                withSpan("syncNonthrowingExample") { span in
+                    print(param)
+                }
+            }
+            """,
+            macros: ["Traced": TracedMacro.self]
+        )
+    }
+
+    func test_tracedMacro_accessSpan() {
+        assertMacroExpansion(
+            """
+            @Traced
+            func example(param: Int) {
+                span.attributes["param"] = param
+            }
+            """,
+            expandedSource: """
+            func example(param: Int) {
+                withSpan("example") { span in
+                    span.attributes["param"] = param
+                }
+            }
+            """,
+            macros: ["Traced": TracedMacro.self]
+        )
+    }
+}
+
+// MARK: Compile tests
+
+@Traced
+func syncNonthrowingExample(param: Int) {
+    print(param)
+}
+
+@Traced
+func example(param: Int) {
+    span.attributes["param"] = param
+}
+
+#endif

--- a/Tests/TracingMacrosTests/TracedTests.swift
+++ b/Tests/TracingMacrosTests/TracedTests.swift
@@ -1,3 +1,7 @@
+import SwiftSyntaxMacrosTestSupport
+import Tracing
+import TracingMacros
+import TracingMacrosImplementation
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Distributed Tracing open source project
@@ -12,11 +16,6 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import SwiftSyntaxMacrosTestSupport
-
-import Tracing
-import TracingMacros
-import TracingMacrosImplementation
 
 #if compiler(>=6.0)
 
@@ -28,10 +27,10 @@ final class TracedMacroTests: XCTestCase {
             func funcWithoutBody()
             """,
             expandedSource: """
-            func funcWithoutBody()
-            """,
+                func funcWithoutBody()
+                """,
             diagnostics: [
-                .init(message: "expected a function with a body", line: 1, column: 1),
+                .init(message: "expected a function with a body", line: 1, column: 1)
             ],
             macros: ["Traced": TracedMacro.self]
         )
@@ -46,12 +45,12 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func syncNonthrowingExample(param: Int) {
-                withSpan("syncNonthrowingExample") { span in
-                    print(param)
+                func syncNonthrowingExample(param: Int) {
+                    withSpan("syncNonthrowingExample") { span in
+                        print(param)
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
     }
@@ -67,14 +66,14 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func syncThrowingExample(param: Int) throws {
-                try withSpan("syncThrowingExample") { span throws in
-                    struct ExampleError: Error {
+                func syncThrowingExample(param: Int) throws {
+                    try withSpan("syncThrowingExample") { span throws in
+                        struct ExampleError: Error {
+                        }
+                        throw ExampleError()
                     }
-                    throw ExampleError()
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
     }
@@ -91,15 +90,15 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func syncRethrowingExample(body: () throws -> Int) rethrows -> Int {
-                try withSpan("syncRethrowingExample") { span throws -> Int in
-                    print("Starting")
-                    let result = try body()
-                    print("Ending")
-                    return result
+                func syncRethrowingExample(body: () throws -> Int) rethrows -> Int {
+                    try withSpan("syncRethrowingExample") { span throws -> Int in
+                        print("Starting")
+                        let result = try body()
+                        print("Ending")
+                        return result
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
     }
@@ -113,12 +112,12 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func asyncNonthrowingExample(param: Int) async {
-                await withSpan("asyncNonthrowingExample") { span async in
-                    print(param)
+                func asyncNonthrowingExample(param: Int) async {
+                    await withSpan("asyncNonthrowingExample") { span async in
+                        print(param)
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
     }
@@ -133,13 +132,13 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func asyncThrowingExample(param: Int) async throws {
-                try await withSpan("asyncThrowingExample") { span async throws in
-                    try await Task.sleep(for: .seconds(1))
-                    print("Hello")
+                func asyncThrowingExample(param: Int) async throws {
+                    try await withSpan("asyncThrowingExample") { span async throws in
+                        try await Task.sleep(for: .seconds(1))
+                        print("Hello")
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
     }
@@ -156,15 +155,15 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func asyncRethrowingExample(body: () async throws -> Int) async rethrows -> Int {
-                try await withSpan("asyncRethrowingExample") { span async throws -> Int in
-                    try? await Task.sleep(for: .seconds(1))
-                    let result = try await body()
-                    span.attributes["result"] = result
-                    return result
+                func asyncRethrowingExample(body: () async throws -> Int) async rethrows -> Int {
+                    try await withSpan("asyncRethrowingExample") { span async throws -> Int in
+                        try? await Task.sleep(for: .seconds(1))
+                        let result = try await body()
+                        span.attributes["result"] = result
+                        return result
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
     }
@@ -183,15 +182,15 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func asyncTypedThrowingExample<Err>(body: () async throws(Err) -> Int) async throws(Err) -> Int {
-                try await withSpan("asyncTypedThrowingExample") { span async throws(Err) -> Int in
-                    try? await Task.sleep(for: .seconds(1))
-                    let result = try await body()
-                    span.attributes["result"] = result
-                    return result
+                func asyncTypedThrowingExample<Err>(body: () async throws(Err) -> Int) async throws(Err) -> Int {
+                    try await withSpan("asyncTypedThrowingExample") { span async throws(Err) -> Int in
+                        try? await Task.sleep(for: .seconds(1))
+                        let result = try await body()
+                        span.attributes["result"] = result
+                        return result
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
     }
@@ -205,12 +204,12 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func example(param: Int) {
-                withSpan("example") { span in
-                    span.attributes["param"] = param
+                func example(param: Int) {
+                    withSpan("example") { span in
+                        span.attributes["param"] = param
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
     }
@@ -224,12 +223,12 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func example(param: Int) {
-                withSpan("example but with a custom operationName") { span in
-                    span.attributes["param"] = param
+                func example(param: Int) {
+                    withSpan("example but with a custom operationName") { span in
+                        span.attributes["param"] = param
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
 
@@ -243,13 +242,13 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            let globalName = "example"
-            func example(param: Int) {
-                withSpan(globalName) { span in
-                    span.attributes["param"] = param
+                let globalName = "example"
+                func example(param: Int) {
+                    withSpan(globalName) { span in
+                        span.attributes["param"] = param
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
     }
@@ -263,12 +262,12 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func example() {
-                withSpan("example", context: .topLevel) { span in
-                    print("Hello")
+                func example() {
+                    withSpan("example", context: .topLevel) { span in
+                        print("Hello")
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
     }
@@ -282,12 +281,12 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func example() {
-                withSpan("example", ofKind: .client) { span in
-                    print("Hello")
+                func example() {
+                    withSpan("example", ofKind: .client) { span in
+                        print("Hello")
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
     }
@@ -301,12 +300,12 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func example(span: String) throws {
-                try withSpan("example") { customSpan throws in
-                    customSpan.attributes["span"] = span
+                func example(span: String) throws {
+                    try withSpan("example") { customSpan throws in
+                        customSpan.attributes["span"] = span
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
 
@@ -318,12 +317,12 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func example(span: String) {
-                withSpan("example") { _ in
-                    print(span)
+                func example(span: String) {
+                    withSpan("example") { _ in
+                        print(span)
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
     }
@@ -337,12 +336,12 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func example(span: String) throws {
-                customSpan.attributes["span"] = span
-            }
-            """,
+                func example(span: String) throws {
+                    customSpan.attributes["span"] = span
+                }
+                """,
             diagnostics: [
-                .init(message: "span name must be a simple string literal", line: 1, column: 1),
+                .init(message: "span name must be a simple string literal", line: 1, column: 1)
             ],
             macros: ["Traced": TracedMacro.self]
         )
@@ -360,13 +359,13 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func example(span: String) throws {
-                customSpan.attributes["span"] = span
-            }
-            func example2(span: String) throws {
-                customSpan.attributes["span"] = span
-            }
-            """,
+                func example(span: String) throws {
+                    customSpan.attributes["span"] = span
+                }
+                func example2(span: String) throws {
+                    customSpan.attributes["span"] = span
+                }
+                """,
             diagnostics: [
                 .init(message: "'invalid name' is not a valid parameter name", line: 1, column: 1),
                 .init(message: "'123' is not a valid parameter name", line: 6, column: 1),
@@ -382,12 +381,12 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func example(span: String) throws {
-                customSpan.attributes["span"] = span
-            }
-            """,
+                func example(span: String) throws {
+                    customSpan.attributes["span"] = span
+                }
+                """,
             diagnostics: [
-                .init(message: "span name must be a simple string literal", line: 1, column: 1),
+                .init(message: "span name must be a simple string literal", line: 1, column: 1)
             ],
             macros: ["Traced": TracedMacro.self]
         )
@@ -402,12 +401,12 @@ final class TracedMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-            func example(span: Int) {
-                withSpan("custom span name", context: .topLevel, ofKind: .client) { customSpan in
-                    customSpan.attributes["span"] = span + 1
+                func example(span: Int) {
+                    withSpan("custom span name", context: .topLevel, ofKind: .client) { customSpan in
+                        customSpan.attributes["span"] = span + 1
+                    }
                 }
-            }
-            """,
+                """,
             macros: ["Traced": TracedMacro.self]
         )
     }


### PR DESCRIPTION
This provides a `@Traced` macro which adds a tracing span around the body of the function. This macro allows customizing the `operationName`, the `context`, and the `kind` of the span, same as the `withSpan` function. It also exposes the span itself into the scope of the function, with a customizable name.

This doesn't attempt to support automatically adding parameters as attributes, because the scoping rules of attached macros aren't very amenable to controlling that. That could be added in the future if it's judged necessary.

## Examples:

```swift
@Traced("preheat oven")
func preheatOven(temperature: Int) async throws -> Oven {
    span.attributes["oven.targetTemperature"] = temperature
    await sleep(for: .seconds(6))
    return Oven()
}
```

expands to:

```swift
func preheatOven(temperature: Int) async throws -> Oven {
    withSpan("preheat oven") { span in
        span.attributes["oven.targetTemperature"] = temperature
        await sleep(for: .seconds(6))
        return Oven()
    }
}
```

## Notes:

This places the macros into a separate product so that users who don't want to pay the compile-time cost of macros don't have to use it, you opt-in to that cost by depending on the `TracingMacros` module.

This adds minimum OS versions for Apple platforms in order to be able to depend on SwiftSyntax. This applies to the whole package since there are no per-target platform specifications. Most notably: This raises the macOS minimum deployment target from the (implicit) 10.13 to 10.15 (matching SwiftSyntax).

Resolves #125