### PR TITLE
Add recordingSpan and currentSpan methods to TracerProtocol

### DIFF
--- a/Sources/Tracing/TracerProtocol.swift
+++ b/Sources/Tracing/TracerProtocol.swift
@@ -66,7 +66,7 @@ public protocol Tracer: LegacyTracer {
     /// It was added retroactively with a default implementation returning `nil` and therefore isn't guaranteed to be implemented by all `Tracer`s.
     /// - Parameter context: The context containing information that uniquely identifies the span being obtained.
     /// - Returns: The span identified by the given `ServiceContext` in case it's still recording.
-    func recordingSpan(identifiedBy context: ServiceContext) -> Span?
+    func activeSpan(identifiedBy context: ServiceContext) -> Span?
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)  // for TaskLocal ServiceContext
@@ -115,12 +115,12 @@ extension Tracer {
         )
     }
 
-    /// Default implementation for ``recordingSpan(identifiedBy:)`` which always returns `nil`.
-    /// This default exists in order to facilitate source-compatible introduction of the ``recordingSpan(identifiedBy:)`` protocol requirement.
+    /// Default implementation for ``activeSpan(identifiedBy:)`` which always returns `nil`.
+    /// This default exists in order to facilitate source-compatible introduction of the ``activeSpan(identifiedBy:)`` protocol requirement.
     ///
     /// - Parameter context: The context containing information that uniquely identifies the span being obtained.
     /// - Returns: `nil`.
-    public func recordingSpan(identifiedBy context: ServiceContext) -> Span? {
+    public func activeSpan(identifiedBy context: ServiceContext) -> Span? {
         nil
     }
 }

--- a/Sources/Tracing/TracerProtocol.swift
+++ b/Sources/Tracing/TracerProtocol.swift
@@ -123,15 +123,6 @@ extension Tracer {
     public func recordingSpan(identifiedBy context: ServiceContext) -> Span? {
         nil
     }
-
-    /// Attempt to retrieve the current recording span based on the task-local `ServiceContext`.
-    ///
-    /// - Note: This method should be considered best-effort as it might not (yet) be supported by the application author's `Tracer` of choice.
-    /// - Returns: A span if one can be obtained via the task-local `ServiceContext`.
-    public func currentSpan() -> Span? {
-        guard let context = ServiceContext.current else { return nil }
-        return recordingSpan(identifiedBy: context)
-    }
 }
 
 // ==== ----------------------------------------------------------------------------------------------------------------

--- a/Sources/Tracing/TracerProtocol.swift
+++ b/Sources/Tracing/TracerProtocol.swift
@@ -59,6 +59,14 @@ public protocol Tracer: LegacyTracer {
         file fileID: String,
         line: UInt
     ) -> Self.Span
+
+    /// Retrieve the recording span for the given `ServiceContext`.
+    ///
+    /// - Note: This API does not enable look up of already finished spans.
+    /// It was added retroactively with a default implementation returning `nil` and therefore isn't guaranteed to be implemented by all `Tracer`s.
+    /// - Parameter context: The context containing information that uniquely identifies the span being obtained.
+    /// - Returns: The span identified by the given `ServiceContext` in case it's still recording.
+    func recordingSpan(identifiedBy context: ServiceContext) -> Span?
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)  // for TaskLocal ServiceContext
@@ -105,6 +113,24 @@ extension Tracer {
             file: fileID,
             line: line
         )
+    }
+
+    /// Default implementation for ``recordingSpan(identifiedBy:)`` which always returns `nil`.
+    /// This default exists in order to facilitate source-compatible introduction of the ``recordingSpan(identifiedBy:)`` protocol requirement.
+    ///
+    /// - Parameter context: The context containing information that uniquely identifies the span being obtained.
+    /// - Returns: `nil`.
+    public func recordingSpan(identifiedBy context: ServiceContext) -> Span? {
+        nil
+    }
+
+    /// Attempt to retrieve the current recording span based on the task-local `ServiceContext`.
+    ///
+    /// - Note: This method should be considered best-effort as it might not (yet) be supported by the application author's `Tracer` of choice.
+    /// - Returns: A span if one can be obtained via the task-local `ServiceContext`.
+    public func currentSpan() -> Span? {
+        guard let context = ServiceContext.current else { return nil }
+        return recordingSpan(identifiedBy: context)
     }
 }
 


### PR DESCRIPTION
**Motivation:**

Currently, it is only possible to implicitly work with the current span by transparently creating a child span (using ServiceContext.current) under the hood. This is sufficient for almost all use-cases, but does not work in case a piece of code wants to add an event to the current span without having a handle on said span, e.g. if the span was created by a library.

The concrete use-case I'm facing is building a tracing "hook" for [my `OpenFeature` client](https://github.com/swift-open-feature/swift-open-feature). `OpenFeature` hooks are similar to middleware, but instead of wrapping a piece of logic they are called before and after a feature flag was evaluated. Therefore, `OpenFeature` implementations in other ecosystems have opted to only add an event instead of creating a new span for the flag evaluation itself:

- [OpenFeature Go SDK: Tracing Hook](https://github.com/open-feature/go-sdk-contrib/blob/629a08258078fc7ee6414390f8bce4faae44c8d2/hooks/open-telemetry/pkg/traces.go#L55)
- [OpenFeature JS SDK: Tracing Hook](https://github.com/open-feature/js-sdk-contrib/blob/e773416a4a0dd67db8e5a79a5ffb2d95b3295714/libs/hooks/open-telemetry/src/lib/traces/tracing-hook.ts#L21)

**Modifications:**

I added a `recordingSpan(identifiedBy context: ServiceContext) -> Span?` requirement to `TracerProtocol`. This way, `Tracer` implementations may look up and return a span identified by the data they stored in the provided `ServiceContext`. It's worth noting that this method is only intended for obtaining spans which are still recording as opposed to already ended ones that may not even be in memory anymore. I also added a default implementation of this method to avoid introducing a breaking change. On top of this new protocol requirement, I added an extension to `TracerProtocol` with sugar to obtain the current span based on the task-local `ServiceContext`.

**Result:**

Library authors and application developers are now able to look up the current recording span to interact with it by e.g. adding events and attributes:

```swift
func spanCreatingMethod() async {
    await withSpan("operation") {
        await methodWithoutSpanArgument()
    }
}

func methodWithoutSpanArgument() async {
    if let span = InstrumentationSystem.tracer.currentSpan() {
        span.addEvent("example")
    }
}
```