### PR TITLE
feat: Add swift wasm compilation support to swift-distributed-tracing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,6 @@ let package = Package(
             name: "_CWASI",
             dependencies: []
         ),
-
     ]
 )
 

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ServiceContextModule", package: "swift-service-context"),
                 .target(name: "Instrumentation"),
+                .target(name: "_CWASI", condition: .when(platforms: [.wasi])),
             ]
         ),
         .testTarget(
@@ -43,6 +44,16 @@ let package = Package(
                 .target(name: "Tracing")
             ]
         ),
+
+        // ==== --------------------------------------------------------------------------------------------------------
+        // MARK: Wasm Support
+
+        // Provides C shims for compiling to wasm
+        .target(
+            name: "_CWASI",
+            dependencies: []
+        ),
+
     ]
 )
 

--- a/Sources/Instrumentation/Locks.swift
+++ b/Sources/Instrumentation/Locks.swift
@@ -35,10 +35,10 @@ import Android
 #elseif canImport(Musl)
 import Musl
 #elseif canImport(WASILibc)
-import WASILibc
-#if canImport(wasi_pthread)
-import wasi_pthread
-#endif
+    import WASILibc
+    #if canImport(wasi_pthread)
+        import wasi_pthread
+    #endif
 #else
 #error("Unsupported runtime")
 #endif

--- a/Sources/Instrumentation/Locks.swift
+++ b/Sources/Instrumentation/Locks.swift
@@ -34,6 +34,11 @@ import Glibc
 import Android
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(WASILibc)
+import WASILibc
+#if canImport(wasi_pthread)
+import wasi_pthread
+#endif
 #else
 #error("Unsupported runtime")
 #endif

--- a/Sources/Tracing/NoOpTracer.swift
+++ b/Sources/Tracing/NoOpTracer.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Dispatch
 @_exported import Instrumentation
 @_exported import ServiceContextModule
 

--- a/Sources/Tracing/Tracer.swift
+++ b/Sources/Tracing/Tracer.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Dispatch
 @_exported import Instrumentation
 @_exported import ServiceContextModule
 

--- a/Sources/Tracing/TracerProtocol+Legacy.swift
+++ b/Sources/Tracing/TracerProtocol+Legacy.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Dispatch
 @_exported import Instrumentation
 @_exported import ServiceContextModule
 

--- a/Sources/Tracing/TracingTime.swift
+++ b/Sources/Tracing/TracingTime.swift
@@ -23,8 +23,14 @@ import Glibc
 import Android
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(WASILibc)
+import WASILibc
 #else
 #error("Unsupported runtime")
+#endif
+
+#if canImport(_CWASI)
+import _CWASI
 #endif
 
 public protocol TracerInstant: Comparable, Hashable, Sendable {

--- a/Sources/Tracing/TracingTime.swift
+++ b/Sources/Tracing/TracingTime.swift
@@ -90,7 +90,11 @@ public struct DefaultTracerClock {
 
     public var now: Self.Instant {
         var ts = timespec()
-        clock_gettime(CLOCK_REALTIME, &ts)
+        #if os(WASI)
+            CWASI_clock_gettime_realtime(&ts)
+        #else
+            clock_gettime(CLOCK_REALTIME, &ts)
+        #endif
         /// We use unsafe arithmetic here because `UInt64.max` nanoseconds is more than 580 years,
         /// and the odds that this code will still be running 530 years from now is very, very low,
         /// so as a practical matter this will never overflow.

--- a/Sources/Tracing/TracingTime.swift
+++ b/Sources/Tracing/TracingTime.swift
@@ -24,13 +24,13 @@ import Android
 #elseif canImport(Musl)
 import Musl
 #elseif canImport(WASILibc)
-import WASILibc
+    import WASILibc
 #else
 #error("Unsupported runtime")
 #endif
 
 #if canImport(_CWASI)
-import _CWASI
+    import _CWASI
 #endif
 
 public protocol TracerInstant: Comparable, Hashable, Sendable {

--- a/Sources/_CWASI/_CWASI.c
+++ b/Sources/_CWASI/_CWASI.c
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Tracing open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Distributed Tracing project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Distributed Tracing project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//

--- a/Sources/_CWASI/include/_CWASI.h
+++ b/Sources/_CWASI/include/_CWASI.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Tracing open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Distributed Tracing project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Distributed Tracing project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#if __wasi__
+
+#include <fcntl.h>
+#include <time.h>
+
+static inline void CWASI_clock_gettime_realtime(struct timespec *tv) {
+    // ClangImporter doesn't support `CLOCK_REALTIME` declaration in WASILibc, thus we have to define a bridge manually
+    clock_gettime(CLOCK_REALTIME, tv);
+}
+
+#endif // __wasi__


### PR DESCRIPTION
# Summary

This PR adds support for compiling swift-distributed-tracing to wasm using the [SwiftWasm](https://swiftwasm.org) sdk.

This PR is [part of a larger effort](https://github.com/PassiveLogic/swift-web-examples/issues/1) by a company called PassiveLogic to enable broad support for SwiftWasm.

# Details

There are three changes required to enable wasm compilation for swift-distributed-tracing.

- Removed unused `import Dispatch` imports. SwiftWasm doesn't currently include GCD. Luckily, all usage of GCD was unused.
- Added some missing wasi-libc and pthread imports
- Add shim to allow wrapped access to CLOCK_REALTIME struct from WASILibc. This is a critical piece of distributed tracing to acquire timestamps that needed some manual shim code to map to the matching API in WASI.

# Testing done

- [x] - Cleaned up swiftformat lint on modified lines of change.
- [x] - Verified unit tests still pass with these changes
- [x] - Verified `swift build` completes without errors
- [x] - Verified `swift build --swift-sdk wasm32-unknown-wasi` completes without errors
- [x] - Verified a third-party executable can build this library as part of a larger wasm executable using the command `swift package --swift-sdk wasm32-unknown-wasip1-threads js --use-cdn`

# Impact Risk

Realistically, this change should not cause any impact or risk. Outside of wasm targets, the changes in this PR are additive.