### PR TITLE
ci: Add swift wasm builds to CI to prevent future breakages to wasm builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,3 +30,9 @@ jobs:
     uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
       build_scheme: swift-distributed-tracing-Package
+
+  wasm-sdk:
+    name: WebAssembly SDK
+    # TODO: Switch to this line after https://github.com/apple/swift-nio/pull/3159/ is merged
+    # uses: apple/swift-nio/.github/workflows/wasm_sdk.yml@main
+    uses: kateinoigakukun/swift-nio/.github/workflows/wasm_sdk.yml@katei/add-wasm-ci

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,6 +23,12 @@ jobs:
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+  
+  wasm-sdk:
+    name: WebAssembly SDK
+    # TODO: Switch to this line after https://github.com/apple/swift-nio/pull/3159/ is merged
+    # uses: apple/swift-nio/.github/workflows/wasm_sdk.yml@main
+    uses: kateinoigakukun/swift-nio/.github/workflows/wasm_sdk.yml@katei/add-wasm-ci
 
   benchmarks:
     name: Benchmarks


### PR DESCRIPTION
⚠️  This PR is blocked from final testing and merging until dependent PR's are merged.

# Change summary

Added swift wasm as a CI target, to help prevent future breakages to swift wasm builds in DataLoader

# Details

- Adds wasm build to `pull_request` and `main`, by adding references to new wasm build workflow from swift-nio.

# Notes

- The new wasm workflow in swift-nio isn't merged yet.
- This PR is [part of a larger effort](https://github.com/PassiveLogic/swift-web-examples/issues/1) by PassiveLogic to add wasm support to many popular repositories.

# PR Dependencies

The following PR's must be merged before this PR can be merged:

- https://github.com/apple/swift-distributed-tracing/pull/174
- https://github.com/apple/swift-nio/pull/3159

# Testing done

Verified new github workflow starts correctly. But cannot verify full functionality until the dependent PR's are merged.

See https://github.com/PassiveLogic/swift-distributed-tracing/actions/runs/15858257532/job/44708826507?pr=1

# Remaining work

- [ ] Update this PR after swift-nio wasm [workflow](https://github.com/apple/swift-nio/pull/3159) is merged to `main`.
- [ ] Run tests on this once all dependent PR's are merged.