### PR TITLE
Enable Swift 6.2 jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,6 +37,7 @@ jobs:
 
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 

--- a/Benchmarks/Thresholds/6.2/TracingBenchmarks.NoopTracing.attribute._set,_span.attributes.http.status_code_=_200.p90.json
+++ b/Benchmarks/Thresholds/6.2/TracingBenchmarks.NoopTracing.attribute._set,_span.attributes.http.status_code_=_200.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 2
+}

--- a/Benchmarks/Thresholds/6.2/TracingBenchmarks.NoopTracing.attribute._set,_span.attributes['http.status_code']_=_200.p90.json
+++ b/Benchmarks/Thresholds/6.2/TracingBenchmarks.NoopTracing.attribute._set,_span.attributes['http.status_code']_=_200.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 1
+}

--- a/Benchmarks/Thresholds/6.2/TracingBenchmarks.NoopTracing.startSpan_endSpan.p90.json
+++ b/Benchmarks/Thresholds/6.2/TracingBenchmarks.NoopTracing.startSpan_endSpan.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 0
+}


### PR DESCRIPTION
Motivation:

Swift 6.2 has been released, we should add it to our CI coverage.

Modifications:

Add additional Swift 6.2 jobs where appropriate in main.yml, pull_request.yml

Result:

Improved test coverage.
