### PR TITLE
ci: Add swift wasm builds to CI to prevent future breakages to wasm builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,10 @@ jobs:
     with:
       build_scheme: swift-distributed-tracing-Package
 
+  wasm-sdk:
+    name: WebAssembly Swift SDK
+    uses: apple/swift-nio/.github/workflows/wasm_sdk.yml@main
+
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,6 +35,10 @@ jobs:
       windows_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+  
+  wasm-sdk:
+    name: WebAssembly Swift SDK
+    uses: apple/swift-nio/.github/workflows/wasm_sdk.yml@main
 
   benchmarks:
     name: Benchmarks


### PR DESCRIPTION
This is just a temporary PR to ensure the changeset compiles and functions properly, before sending the changeset off to swift lang's repos.