### PR TITLE
Make `withSpan` set span status to `.error` if operation closure throws

### DIFF
--- a/Sources/Tracing/TracerProtocol+Legacy.swift
+++ b/Sources/Tracing/TracerProtocol+Legacy.swift
@@ -229,6 +229,7 @@ extension LegacyTracer {
             }
         } catch {
             span.recordError(error)
+            span.setStatus(.init(code: .error))
             throw error  // rethrow
         }
     }
@@ -333,6 +334,7 @@ extension LegacyTracer {
             }
         } catch {
             span.recordError(error)
+            span.setStatus(.init(code: .error))
             throw error  // rethrow
         }
     }
@@ -383,6 +385,7 @@ extension LegacyTracer {
             }
         } catch {
             span.recordError(error)
+            span.setStatus(.init(code: .error))
             throw error  // rethrow
         }
     }
@@ -437,6 +440,7 @@ extension LegacyTracer {
             }
         } catch {
             span.recordError(error)
+            span.setStatus(.init(code: .error))
             throw error  // rethrow
         }
     }
@@ -485,6 +489,7 @@ extension LegacyTracer {
             }
         } catch {
             span.recordError(error)
+            span.setStatus(.init(code: .error))
             throw error  // rethrow
         }
     }

--- a/Sources/Tracing/TracerProtocol.swift
+++ b/Sources/Tracing/TracerProtocol.swift
@@ -180,6 +180,7 @@ extension Tracer {
             }
         } catch {
             span.recordError(error)
+            span.setStatus(.init(code: .error))
             throw error  // rethrow
         }
     }
@@ -231,6 +232,7 @@ extension Tracer {
             }
         } catch {
             span.recordError(error)
+            span.setStatus(.init(code: .error))
             throw error  // rethrow
         }
     }
@@ -284,6 +286,7 @@ extension Tracer {
             }
         } catch {
             span.recordError(error)
+            span.setStatus(.init(code: .error))
             throw error  // rethrow
         }
     }
@@ -321,6 +324,7 @@ extension Tracer {
             }
         } catch {
             span.recordError(error)
+            span.setStatus(.init(code: .error))
             throw error  // rethrow
         }
     }
@@ -375,6 +379,7 @@ extension Tracer {
             }
         } catch {
             span.recordError(error)
+            span.setStatus(.init(code: .error))
             throw error  // rethrow
         }
     }
@@ -425,6 +430,7 @@ extension Tracer {
             }
         } catch {
             span.recordError(error)
+            span.setStatus(.init(code: .error))
             throw error  // rethrow
         }
     }

--- a/Tests/TracingTests/TestTracer.swift
+++ b/Tests/TracingTests/TestTracer.swift
@@ -120,7 +120,7 @@ extension ServiceContext {
 final class TestSpan: Span {
     let kind: SpanKind
 
-    private var status: SpanStatus?
+    var status: SpanStatus?
 
     package let startTimestampNanosSinceEpoch: UInt64
     package private(set) var endTimestampNanosSinceEpoch: UInt64?


### PR DESCRIPTION
**Motivation:**

Span status is relied upon by application developers to quickly discover spans that have thrown a exception.

**Modifications:**

Ensure that all tracer protocols set the span status to `.error` when the underlying operation closure throws during execution.

**Result:**

When an error is thrown from a `withSpan` operation closure the underlying span has an `.error` span status code on return.

Closes: #200 