### PR TITLE
Drop Swift 6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,19 +14,16 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_3_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      windows_6_0_enabled: true
       windows_6_1_enabled: true
       windows_6_2_enabled: true
       windows_6_3_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true
-      windows_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_6_3_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,19 +20,16 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_3_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      windows_6_0_enabled: true
       windows_6_1_enabled: true
       windows_6_2_enabled: true
       windows_6_3_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true
-      windows_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_6_3_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/Benchmarks/Benchmarks/TracingBenchmarks/AtrributeDSLBenchmark.swift
+++ b/Benchmarks/Benchmarks/TracingBenchmarks/AtrributeDSLBenchmark.swift
@@ -15,7 +15,7 @@
 import Benchmark
 import Tracing
 
-let benchmarks = {
+let benchmarks: @Sendable () -> Void = {
     let defaultMetrics: [BenchmarkMetric] = [
         .mallocCountTotal
     ]

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version:6.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Distributed Tracing open source project

--- a/Benchmarks/Thresholds/6.0/TracingBenchmarks.NoopTracing.attribute._set,_span.attributes.http.status_code_=_200.p90.json
+++ b/Benchmarks/Thresholds/6.0/TracingBenchmarks.NoopTracing.attribute._set,_span.attributes.http.status_code_=_200.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 2
-}

--- a/Benchmarks/Thresholds/6.0/TracingBenchmarks.NoopTracing.attribute._set,_span.attributes['http.status_code']_=_200.p90.json
+++ b/Benchmarks/Thresholds/6.0/TracingBenchmarks.NoopTracing.attribute._set,_span.attributes['http.status_code']_=_200.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 1
-}

--- a/Benchmarks/Thresholds/6.0/TracingBenchmarks.NoopTracing.startSpan_endSpan.p90.json
+++ b/Benchmarks/Thresholds/6.0/TracingBenchmarks.NoopTracing.startSpan_endSpan.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 0
-}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 import PackageDescription
 
 let package = Package(

--- a/Samples/Dinner/Package.swift
+++ b/Samples/Dinner/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:6.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Distributed Tracing open source project


### PR DESCRIPTION
Motivation:

Swift 6.0 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 6.1
* Remove Swift 6.0 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
