### PR TITLE
Make dependabot set  label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    labels:
+      - "semver/none"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Prompt: Make dependabot set  label

Claude output:
Both changes are already in place:

1. The `labels: ["semver/none"]` is configured (line 5-6).
2. The schedule interval is already set to `"daily"` (line 8).

No further changes needed — the file is already up to date.
