### PR TITLE
Add lightweight proposals process to swift-distributed-tracing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,8 @@ directory, for example:
 
 ## How to contribute your work
 
+For non-trivial changes that affect the public API, it is good practice to have a discussion phase before writing code. Please follow the [proposal process](Sources/Tracing/Docs.docc/Proposals/Proposals.md) to gather feedback and align on the approach with other contributors.
+
 Please open a pull request at https://github.com/apple/swift-distributed-tracing. Make sure the CI passes, and then wait for code review.
 
 ## Automated release process

--- a/Sources/Tracing/Docs.docc/Proposals/Proposals.md
+++ b/Sources/Tracing/Docs.docc/Proposals/Proposals.md
@@ -1,0 +1,47 @@
+# Proposals
+
+Collaborate on API changes to Swift Distributed Tracing by writing a proposal.
+
+## Overview
+
+For non-trivial changes that affect the public API, the Swift Distributed Tracing project adopts a lightweight version
+of the [Swift Evolution](https://github.com/apple/swift-evolution/blob/main/process.md) process.
+
+Writing a proposal first helps you discuss multiple possible solutions early, apply useful feedback from other
+contributors, and avoid reimplementing the same feature multiple times.
+
+Get feedback early by opening a pull request with your proposal, but also consider the complexity of the implementation
+when evaluating different solutions. For example, include a link to a branch containing a prototype implementation of
+the feature in the pull request description.
+
+> Note: The goal of this process is to solicit feedback from the whole community around the project, and the project
+> continues to refine the proposal process itself. Use your best judgment, and don't hesitate to propose changes to
+> the proposal structure itself.
+
+### Steps
+
+1. Make sure there's a GitHub issue for the feature or change you would like to propose.
+2. Duplicate the `SDT-NNNN.md` document and replace `NNNN` with the next available proposal number.
+3. Link the GitHub issue from your proposal, and fill in the proposal.
+4. Open a pull request with your proposal and solicit feedback from other contributors.
+5. Once a maintainer confirms that the proposal is ready for review, we update the state accordingly. The review period
+   is 7 days, and ends when one of the maintainers marks the proposal as Ready for Implementation, or Deferred.
+6. Before merging the pull request, ensure an implementation is ready, either in the same pull request or in a separate
+   one linked from the proposal.
+7. A proposal becomes Approved once you merge the implementation and proposal PRs, and enable any feature flags
+   unconditionally.
+
+If you have any questions, ask in an issue on GitHub.
+
+### Possible review states
+
+- Awaiting Review
+- In Review
+- Ready for Implementation
+- In Preview
+- Approved
+- Deferred
+
+## Topics
+
+- <doc:SDT-NNNN>

--- a/Sources/Tracing/Docs.docc/Proposals/SDT-NNNN.md
+++ b/Sources/Tracing/Docs.docc/Proposals/SDT-NNNN.md
@@ -1,0 +1,51 @@
+# SDT-NNNN: Feature name
+
+Feature abstract – a one sentence summary.
+
+## Overview
+
+- Proposal: SDT-NNNN
+- Author(s): [Author 1](https://github.com/swiftdev), [Author 2](https://github.com/swiftdev)
+- Status: **Awaiting Review**
+- Issue: [apple/swift-distributed-tracing#1](https://github.com/apple/swift-distributed-tracing/issues/1)
+- Implementation:
+    - [apple/swift-distributed-tracing#1](https://github.com/apple/swift-distributed-tracing/pull/1)
+- Feature flag: `proposalNNNN`
+- Related links:
+    - [Lightweight proposals process description](https://github.com/apple/swift-distributed-tracing/blob/main/Sources/Tracing/Docs.docc/Proposals/Proposals.md)
+
+### Introduction
+
+A short, one-sentence overview of the feature or change.
+
+### Motivation
+
+Describe the problems that this proposal addresses, and what workarounds adopters currently use, if any.
+
+### Proposed solution
+
+Describe your solution to the problem. Provide examples and describe how they work. Show how your solution is better
+than current workarounds.
+
+Focus this section on what will change for the _adopters_ of Swift Distributed Tracing.
+
+### Detailed design
+
+Describe the implementation of the feature. Include a link to a prototype implementation.
+
+Focus this section on what will change for the _contributors_ to Swift Distributed Tracing.
+
+### API stability
+
+Discuss the API implications, making sure to consider all of:
+- existing ``Tracer`` implementations
+- existing ``Instrument`` implementations
+- existing users of the tracing and instrumentation APIs
+
+### Future directions
+
+Discuss any potential future improvements to the feature.
+
+### Alternatives considered
+
+Discuss the alternative solutions you considered, even during the review process itself.

--- a/Sources/Tracing/Docs.docc/Proposals/SDT-NNNN.md
+++ b/Sources/Tracing/Docs.docc/Proposals/SDT-NNNN.md
@@ -38,8 +38,8 @@ Focus this section on what will change for the _contributors_ to Swift Distribut
 ### API stability
 
 Discuss the API implications, making sure to consider all of:
-- existing ``Tracer`` implementations
-- existing ``Instrument`` implementations
+- existing `Tracer` implementations
+- existing `Instrument` implementations
 - existing users of the tracing and instrumentation APIs
 
 ### Future directions

--- a/Sources/Tracing/Docs.docc/index.md
+++ b/Sources/Tracing/Docs.docc/index.md
@@ -72,3 +72,7 @@ as the subsequent guides dive deeper into patterns and details of instrumenting 
 
 - ``DefaultTracerClock``
 - ``NoOpTracer``
+
+### Contribute to the project
+
+- <doc:Proposals>


### PR DESCRIPTION
For non-trivial changes that affect the public API, the SwiftLog project adopts a lightweight version of the [Swift Evolution](https://github.com/apple/swift-evolution/blob/main/process.md) process.

## Motivation:

Writing a proposal first helps discuss multiple possible solutions early, apply useful feedback from other contributors, and avoid reimplementing the same feature multiple times.

## Modifications:

Proposals process description and a proposal template added to the documentation.

## Result:

Proposals can now be submitted to the Swift Distributed Tracing.