### PR TITLE
Disable nightly 6.3 WASM builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,8 @@ jobs:
   wasm-sdk:
     name: WebAssembly Swift SDK
     uses: apple/swift-nio/.github/workflows/wasm_swift_sdk.yml@main
+    with:
+      nightly_next_enabled: false
 
   release-builds:
     name: Release builds

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,6 +39,8 @@ jobs:
   wasm-sdk:
     name: WebAssembly Swift SDK
     uses: apple/swift-nio/.github/workflows/wasm_swift_sdk.yml@main
+    with:
+      nightly_next_enabled: false
 
   benchmarks:
     name: Benchmarks


### PR DESCRIPTION
Disable nightly WASM builds because 6.3 images are no longer available. Enable back when 6.4 builds are available.