### PR TITLE
[SDT-0001]: task-local tracer proposal

### DIFF
--- a/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-instrument.md
+++ b/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-instrument.md
@@ -7,7 +7,7 @@ cost to apps that don't use it.
 
 - Proposal: SDT-0001
 - Author(s): [Vladimir Kukushkin](https://github.com/kukushechkin)
-- Status: **In Review**
+- Status: **Deferred**
 - Issue: [apple/swift-distributed-tracing#168](https://github.com/apple/swift-distributed-tracing/issues/168)
 - Implementation: [apple/swift-distributed-tracing#230](https://github.com/apple/swift-distributed-tracing/pull/230)
 

--- a/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-instrument.md
+++ b/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-instrument.md
@@ -1,0 +1,167 @@
+# SDT-0001: task-local instrument
+
+A `withInstrument(_:_:)` free function that scopes an ``Instrument`` to the current task. Opt-in, with no
+cost to apps that don't use it.
+
+## Overview
+
+- Proposal: SDT-0001
+- Author(s): [Vladimir Kukushkin](https://github.com/kukushechkin)
+- Status: **In Review**
+- Issue: [apple/swift-distributed-tracing#168](https://github.com/apple/swift-distributed-tracing/issues/168)
+- Implementation: [apple/swift-distributed-tracing#230](https://github.com/apple/swift-distributed-tracing/pull/230)
+
+### Introduction
+
+This proposal adds the ``withInstrument(_:_:)`` free function. It runs a closure with a chosen ``Instrument``
+active for the current task and any child tasks it spawns. Unlike ``InstrumentationSystem/bootstrap(_:)``,
+which is set once per process, it can bind a different instrument per region of work, for example per test.
+
+### Motivation
+
+``InstrumentationSystem/bootstrap(_:)`` installs an instrument **once** per process. From then on, every
+`withSpan` / `startSpan` call and every read of ``InstrumentationSystem/instrument`` resolves through that one
+instrument. This fits "one tracer for the whole application". It makes per-test instruments hard, though: a
+second `bootstrap` call crashes, so parallel tests can't each install their own.
+
+### Proposed solution
+
+``withInstrument(_:_:)`` runs a closure with an instrument active for the current task:
+
+```swift
+// Unit test — parallel-safe. The binding is task-local, so concurrent tests don't interfere.
+@Test func spansAreCaptured() async {
+    let tracer = InMemoryTracer()
+    await withInstrument(tracer) {
+        await withSpan("op") { _ in }   // emits into `tracer`
+    }
+    #expect(tracer.spans.count == 1)
+}
+```
+
+Inside the closure — and in any child tasks it spawns — `instrument` is the active instrument, so span
+creation (``InstrumentationSystem/tracer``, `withSpan` / `startSpan`) and propagation (`inject` / `extract`)
+resolve through it. The binding is task-local, so a nested `withInstrument` applies only within its own
+closure. It replaces rather than merges: to run several instruments at once, pass a ``MultiplexInstrument``,
+exactly as you would to `bootstrap`.
+
+### Detailed design
+
+````swift
+/// Makes `instrument` the active instrument for the current task and the child tasks it spawns, for the
+/// duration of `operation`.
+///
+/// `withInstrument(_:_:)` works through a dedicated task-local instrument that the ``InstrumentationSystem``
+/// holds as its bootstrap. The first call installs it — a one-time global bootstrap, done only when nothing
+/// else is bootstrapped — and every call then sets `instrument` as the active instrument for the closure,
+/// replacing any instrument an enclosing `withInstrument(_:_:)` set. Discovery (``InstrumentationSystem/tracer``,
+/// free-function `withSpan` / `startSpan`) and propagation (`inject` / `extract`) resolve through `instrument`.
+/// To keep several instruments active at once, pass a ``MultiplexInstrument`` built from the instruments you
+/// hold.
+///
+/// ```swift
+/// // Parallel-safe. The binding is task-local, so concurrent tests don't interfere.
+/// @Test func spansAreCaptured() async {
+///     let tracer = InMemoryTracer()
+///     await withInstrument(tracer) {
+///         await withSpan("op") { _ in }   // emits into `tracer`
+///     }
+///     #expect(tracer.spans.count == 1)
+/// }
+/// ```
+///
+/// > Important: This is an application-level facility — call it from code that owns the instrumentation setup,
+/// > never from a library. It can install its instrument only when the ``InstrumentationSystem`` is otherwise
+/// > un-bootstrapped. Calling it after a plain ``Instrument`` has been bootstrapped crashes. Libraries emit
+/// > through ``InstrumentationSystem/instrument`` and `withSpan` / `startSpan`, which already observe whatever
+/// > is active.
+///
+/// > Important: `instrument` replaces the active instrument for the scope, it does not merge with it. Include
+/// > a tracer (directly or inside a ``MultiplexInstrument``) if you want spans recorded inside the closure.
+/// > Passing ``InstrumentationSystem/instrument`` back in is rejected with a crash.
+///
+/// - Parameters:
+///   - instrument: The instrument to make active for the duration of `operation`.
+///   - operation: The closure to run with `instrument` active.
+/// - Returns: The value returned by the closure.
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public func withInstrument<Result, Failure: Error>(
+    _ instrument: any Instrument,
+    _ operation: () throws(Failure) -> Result
+) throws(Failure) -> Result
+
+#if compiler(>=6.2)
+/// Makes `instrument` the active instrument for the current task and the child tasks it spawns, for the
+/// duration of `operation`. See the synchronous `withInstrument(_:_:)` for the full discussion — replace
+/// semantics, the application-level / plain-bootstrap rules, and the self-reference crash.
+///
+/// - Parameters:
+///   - instrument: The instrument to make active for the duration of `operation`.
+///   - operation: The async closure to run with `instrument` active.
+/// - Returns: The value returned by the closure.
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public nonisolated(nonsending) func withInstrument<Result, Failure: Error>(
+    _ instrument: any Instrument,
+    _ operation: nonisolated(nonsending) () async throws(Failure) -> Result
+) async throws(Failure) -> Result
+#else
+/// Makes `instrument` the active instrument for the current task and the child tasks it spawns, for the
+/// duration of `operation`. See the synchronous `withInstrument(_:_:)` for the full discussion — replace
+/// semantics, the application-level / plain-bootstrap rules, and the self-reference crash.
+///
+/// - Parameters:
+///   - instrument: The instrument to make active for the duration of `operation`.
+///   - operation: The async closure to run with `instrument` active.
+/// - Returns: The value returned by the closure.
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public func withInstrument<Result, Failure: Error>(
+    _ instrument: any Instrument,
+    isolation: isolated (any Actor)? = #isolation,
+    _ operation: () async throws(Failure) -> Result
+) async throws(Failure) -> Result
+#endif
+````
+
+That dedicated instrument is an internal type, `TaskLocalInstrument` — not public, so applications cannot
+construct or name it. It holds the `@TaskLocal` override and falls back to an inner ``NoOpInstrument``.
+
+### API stability
+
+- Applications that never call ``withInstrument(_:_:)`` see no behavioral change.
+
+### Future directions
+
+- **Accumulate active instruments, not just replacing.** `withInstrument` replaces. A future variant —
+  `withInstrument(merging:)`, or a form that passes the current instrument into a builder closure — could let
+  a caller compose with whatever is already active without having to name it. The library would supply the
+  concrete current instrument, keeping it safe from the self-reference crash that blocks composing
+  ``InstrumentationSystem/instrument`` by hand today.
+
+### Alternatives considered
+
+**Task-local slot on ``InstrumentationSystem/instrument``.** Read the task-local on every `instrument` access
+rather than behind an installed instrument. Rejected: it taxes every read even when no scope is active and
+pushes scope-awareness into ``InstrumentationSystem``.
+
+**Public `TaskLocalInstrument` to bootstrap directly.** Make `TaskLocalInstrument` a public type that
+applications bootstrap directly (`InstrumentationSystem.bootstrap(TaskLocalInstrument(tracer))`), entering
+scopes via a static `TaskLocalInstrument.with(_:_:)`. Rejected: a single free function matches the `withSpan`
+/ `withMetricsFactory` precedent and avoids forcing a plain-vs-wrapped choice at bootstrap and compatibilities
+with libraries doing instrumentation.
+
+**Accumulate nested scopes instead of replacing.** Push onto a task-local stack so a nested scope adds to,
+rather than replaces, the enclosing one. Rejected: it is a hidden, surprising accumulation, and the use case
+it serves — augmenting whatever is already active — cannot be offered cleanly anyway, since
+``InstrumentationSystem/instrument`` is a scope-aware wrapper rather than a concrete value (see above).
+Replacing is simpler and matches swift-metrics' `withMetricsFactory`. Pass a ``MultiplexInstrument`` to run
+several instruments at once.
+
+**Task-local ``Tracer`` only.** Rejected: leaves ``InstrumentationSystem/instrument`` global, so `extract` /
+`inject` wouldn't see the scope — a test would capture spans but miss incoming trace IDs.
+
+**Expose `bootstrapInternal` for tests.** Rejected: solves only testing, keeps the one-shot global model, and
+gives libraries no per-request scoping.
+
+**Pass the instrument to the closure** (`withInstrument(x) { x in … }`). Rejected: library code uses
+``InstrumentationSystem/instrument`` and `withSpan`, not the instrument directly. Passing it would push people
+toward direct use.

--- a/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-instrument.md
+++ b/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-instrument.md
@@ -61,6 +61,11 @@ within one task-local scope, see Future directions.
 /// set. An unstructured `Task { }` inherits the binding. `Task.detached` does not. Nesting
 /// `withTracer(_:_:)` overrides `tracer` for the inner scope only.
 ///
+/// Checks the task-local first, and only reads the bootstrapped instrument if it is not set. A resolution
+/// inside this scope returns from the task-local directly and never touches the bootstrapped storage. An
+/// application that only calls ``InstrumentationSystem/bootstrap(_:)`` pays for that extra check on
+/// every lookup.
+///
 /// ```swift
 /// // Parallel-safe. The binding is task-local, so concurrent tests don't interfere.
 /// @Test func spansAreCaptured() async {
@@ -118,15 +123,19 @@ public func withTracer<Result, Failure: Error>(
 ````
 
 The scope is backed by an `@TaskLocal` on ``InstrumentationSystem`` typed `(any Instrument)?`. There is no
-wrapper instrument, and nothing is installed on first use.
+wrapper instrument, and nothing is installed on first use. ``InstrumentationSystem/instrument`` and the other
+resolution methods (``InstrumentationSystem/tracer``, ``InstrumentationSystem/_findInstrument(where:)``) check
+that task-local first, and only read the bootstrapped instrument if it is not set.
 
 ### API stability
 
 - Purely additive: a new free function and an internal task-local. Existing signatures are unchanged.
 - Applications that never call ``withTracer(_:_:)`` see no behavioral change. Instrument lookup now checks a
   task-local before falling back to the bootstrapped instrument.
-- That task-local read happens on every lookup, including the per-span `withSpan` / `startSpan` path. The
-  added cost is negligible next to the work a real tracer already does per span.
+- That task-local read happens on every lookup, including the per-span `withSpan` / `startSpan` path. An
+  application that only calls ``bootstrap(_:)`` pays for this extra check every time, negligible next to what a
+  real tracer already does per span. A resolution inside `withTracer(_:_:)` returns from the task-local
+  directly, and never reads the bootstrapped storage at all.
 
 ### Future directions
 

--- a/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-instrument.md
+++ b/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-instrument.md
@@ -1,167 +1,177 @@
 # SDT-0001: task-local instrument
 
-A `withInstrument(_:_:)` free function that scopes an ``Instrument`` to the current task. Opt-in, with no
-cost to apps that don't use it.
+A ``withTracer(_:_:)`` free function that binds a ``Tracer`` to the current task. It takes priority over the
+process-wide ``InstrumentationSystem/bootstrap(_:)`` for the scope, then falls back to it.
 
 ## Overview
 
 - Proposal: SDT-0001
 - Author(s): [Vladimir Kukushkin](https://github.com/kukushechkin)
-- Status: **Deferred**
+- Status: **In Review**
 - Issue: [apple/swift-distributed-tracing#168](https://github.com/apple/swift-distributed-tracing/issues/168)
-- Implementation: [apple/swift-distributed-tracing#230](https://github.com/apple/swift-distributed-tracing/pull/230)
+- Implementation: on the `SDT-0001-task-local-instrument-implementation` branch
 
 ### Introduction
 
-This proposal adds the ``withInstrument(_:_:)`` free function. It runs a closure with a chosen ``Instrument``
-active for the current task and any child tasks it spawns. Unlike ``InstrumentationSystem/bootstrap(_:)``,
-which is set once per process, it can bind a different instrument per region of work, for example per test.
+This proposal adds the ``withTracer(_:_:)`` free function. It runs a closure with a chosen ``Tracer`` active
+for the current task and any child tasks it spawns. Unlike ``InstrumentationSystem/bootstrap(_:)``, which is
+set once per process, ``withTracer(_:_:)`` can bind a different tracer per region of work, for example per test.
 
 ### Motivation
 
 ``InstrumentationSystem/bootstrap(_:)`` installs an instrument **once** per process. From then on, every
 `withSpan` / `startSpan` call and every read of ``InstrumentationSystem/instrument`` resolves through that one
-instrument. This fits "one tracer for the whole application". It makes per-test instruments hard, though: a
-second `bootstrap` call crashes, so parallel tests can't each install their own.
+instrument. This fits "one tracer for the whole application." Per-test tracers are hard, though. A second
+`bootstrap` call crashes, so parallel tests can't each install their own.
 
 ### Proposed solution
 
-``withInstrument(_:_:)`` runs a closure with an instrument active for the current task:
+``withTracer(_:_:)`` runs a closure with a tracer active for the current task:
 
 ```swift
-// Unit test — parallel-safe. The binding is task-local, so concurrent tests don't interfere.
+// Parallel-safe unit test. The binding is task-local, so concurrent tests don't interfere.
 @Test func spansAreCaptured() async {
     let tracer = InMemoryTracer()
-    await withInstrument(tracer) {
+    await withTracer(tracer) {
         await withSpan("op") { _ in }   // emits into `tracer`
     }
-    #expect(tracer.spans.count == 1)
+    #expect(tracer.finishedSpans.count == 1)
 }
 ```
 
-Inside the closure — and in any child tasks it spawns — `instrument` is the active instrument, so span
-creation (``InstrumentationSystem/tracer``, `withSpan` / `startSpan`) and propagation (`inject` / `extract`)
-resolve through it. The binding is task-local, so a nested `withInstrument` applies only within its own
-closure. It replaces rather than merges: to run several instruments at once, pass a ``MultiplexInstrument``,
-exactly as you would to `bootstrap`.
+Inside the closure, and in any child tasks it spawns, `tracer` is the active instrument. Span creation
+(``InstrumentationSystem/tracer``, `withSpan` / `startSpan`) and propagation (`inject` / `extract`) give it
+priority over whatever ``InstrumentationSystem/bootstrap(_:)`` set, because a ``Tracer`` is an ``Instrument``.
+Outside the closure, or in tasks that don't inherit the binding, resolution falls back to the bootstrapped
+instrument. Nesting ``withTracer(_:_:)`` overrides `tracer` for the inner scope only.
+
+``withTracer(_:_:)`` only accepts a ``Tracer``, not an arbitrary ``Instrument``. `MultiplexInstrument` is not
+a `Tracer` either, so while several tools can still be installed together at
+``InstrumentationSystem/bootstrap(_:)`` for the whole process, there is no supported way to combine them
+within one task-local scope, see Future directions.
 
 ### Detailed design
 
 ````swift
-/// Makes `instrument` the active instrument for the current task and the child tasks it spawns, for the
+/// Makes `tracer` the active instrument for the current task and the child tasks it spawns, for the
 /// duration of `operation`.
 ///
-/// `withInstrument(_:_:)` works through a dedicated task-local instrument that the ``InstrumentationSystem``
-/// holds as its bootstrap. The first call installs it — a one-time global bootstrap, done only when nothing
-/// else is bootstrapped — and every call then sets `instrument` as the active instrument for the closure,
-/// replacing any instrument an enclosing `withInstrument(_:_:)` set. Discovery (``InstrumentationSystem/tracer``,
-/// free-function `withSpan` / `startSpan`) and propagation (`inject` / `extract`) resolve through `instrument`.
-/// To keep several instruments active at once, pass a ``MultiplexInstrument`` built from the instruments you
-/// hold.
+/// ``InstrumentationSystem/instrument``, ``InstrumentationSystem/tracer``, `withSpan` / `startSpan`, and
+/// propagation (`inject` / `extract`) all favor `tracer` over whatever ``InstrumentationSystem/bootstrap(_:)``
+/// set. An unstructured `Task { }` inherits the binding. `Task.detached` does not. Nesting
+/// `withTracer(_:_:)` overrides `tracer` for the inner scope only.
 ///
 /// ```swift
 /// // Parallel-safe. The binding is task-local, so concurrent tests don't interfere.
 /// @Test func spansAreCaptured() async {
 ///     let tracer = InMemoryTracer()
-///     await withInstrument(tracer) {
+///     await withTracer(tracer) {
 ///         await withSpan("op") { _ in }   // emits into `tracer`
 ///     }
-///     #expect(tracer.spans.count == 1)
+///     #expect(tracer.finishedSpans.count == 1)
 /// }
 /// ```
 ///
-/// > Important: This is an application-level facility — call it from code that owns the instrumentation setup,
-/// > never from a library. It can install its instrument only when the ``InstrumentationSystem`` is otherwise
-/// > un-bootstrapped. Calling it after a plain ``Instrument`` has been bootstrapped crashes. Libraries emit
-/// > through ``InstrumentationSystem/instrument`` and `withSpan` / `startSpan`, which already observe whatever
-/// > is active.
-///
-/// > Important: `instrument` replaces the active instrument for the scope, it does not merge with it. Include
-/// > a tracer (directly or inside a ``MultiplexInstrument``) if you want spans recorded inside the closure.
-/// > Passing ``InstrumentationSystem/instrument`` back in is rejected with a crash.
+/// A ``Tracer`` is also an ``Instrument``, so this replaces propagation too, not just span creation. To keep
+/// several tools active at once, install a ``MultiplexInstrument`` at ``InstrumentationSystem/bootstrap(_:)``.
 ///
 /// - Parameters:
-///   - instrument: The instrument to make active for the duration of `operation`.
-///   - operation: The closure to run with `instrument` active.
+///   - tracer: The tracer to make active for the duration of `operation`.
+///   - operation: The closure to run with `tracer` active.
 /// - Returns: The value returned by the closure.
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-public func withInstrument<Result, Failure: Error>(
-    _ instrument: any Instrument,
+public func withTracer<Result, Failure: Error>(
+    _ tracer: any Tracer,
     _ operation: () throws(Failure) -> Result
 ) throws(Failure) -> Result
 
 #if compiler(>=6.2)
-/// Makes `instrument` the active instrument for the current task and the child tasks it spawns, for the
-/// duration of `operation`. See the synchronous `withInstrument(_:_:)` for the full discussion — replace
-/// semantics, the application-level / plain-bootstrap rules, and the self-reference crash.
+/// Makes `tracer` the active instrument for the current task and the child tasks it spawns, for the
+/// duration of `operation`. See the synchronous `withTracer(_:_:)` for the full discussion of replace
+/// semantics and the bootstrap fallback.
 ///
 /// - Parameters:
-///   - instrument: The instrument to make active for the duration of `operation`.
-///   - operation: The async closure to run with `instrument` active.
+///   - tracer: The tracer to make active for the duration of `operation`.
+///   - operation: The async closure to run with `tracer` active.
 /// - Returns: The value returned by the closure.
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-public nonisolated(nonsending) func withInstrument<Result, Failure: Error>(
-    _ instrument: any Instrument,
+public nonisolated(nonsending) func withTracer<Result, Failure: Error>(
+    _ tracer: any Tracer,
     _ operation: nonisolated(nonsending) () async throws(Failure) -> Result
 ) async throws(Failure) -> Result
 #else
-/// Makes `instrument` the active instrument for the current task and the child tasks it spawns, for the
-/// duration of `operation`. See the synchronous `withInstrument(_:_:)` for the full discussion — replace
-/// semantics, the application-level / plain-bootstrap rules, and the self-reference crash.
+/// Makes `tracer` the active instrument for the current task and the child tasks it spawns, for the
+/// duration of `operation`. See the synchronous `withTracer(_:_:)` for the full discussion of replace
+/// semantics and the bootstrap fallback.
 ///
 /// - Parameters:
-///   - instrument: The instrument to make active for the duration of `operation`.
-///   - operation: The async closure to run with `instrument` active.
+///   - tracer: The tracer to make active for the duration of `operation`.
+///   - operation: The async closure to run with `tracer` active.
 /// - Returns: The value returned by the closure.
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-public func withInstrument<Result, Failure: Error>(
-    _ instrument: any Instrument,
+public func withTracer<Result, Failure: Error>(
+    _ tracer: any Tracer,
     isolation: isolated (any Actor)? = #isolation,
     _ operation: () async throws(Failure) -> Result
 ) async throws(Failure) -> Result
 #endif
 ````
 
-That dedicated instrument is an internal type, `TaskLocalInstrument` — not public, so applications cannot
-construct or name it. It holds the `@TaskLocal` override and falls back to an inner ``NoOpInstrument``.
+The scope is backed by an `@TaskLocal` on ``InstrumentationSystem`` typed `(any Instrument)?`. There is no
+wrapper instrument, and nothing is installed on first use.
 
 ### API stability
 
-- Applications that never call ``withInstrument(_:_:)`` see no behavioral change.
+- Purely additive: a new free function and an internal task-local. Existing signatures are unchanged.
+- Applications that never call ``withTracer(_:_:)`` see no behavioral change. Instrument lookup now checks a
+  task-local before falling back to the bootstrapped instrument.
+- That task-local read happens on every lookup, including the per-span `withSpan` / `startSpan` path. The
+  added cost is negligible next to the work a real tracer already does per span.
 
 ### Future directions
 
-- **Accumulate active instruments, not just replacing.** `withInstrument` replaces. A future variant —
-  `withInstrument(merging:)`, or a form that passes the current instrument into a builder closure — could let
-  a caller compose with whatever is already active without having to name it. The library would supply the
-  concrete current instrument, keeping it safe from the self-reference crash that blocks composing
-  ``InstrumentationSystem/instrument`` by hand today.
+- **Combining several tools in one scope.** ``withTracer(_:_:)`` only takes one `Tracer`. There is no built-in
+  way to task-locally combine a tracer with extra propagators, or several tracers at once. A wrapper type
+  that groups several instruments behind one `Tracer` conformance, something like a `MultiplexTracer`, could
+  close this gap without changing ``withTracer(_:_:)`` itself.
 
 ### Alternatives considered
 
-**Task-local slot on ``InstrumentationSystem/instrument``.** Read the task-local on every `instrument` access
-rather than behind an installed instrument. Rejected: it taxes every read even when no scope is active and
-pushes scope-awareness into ``InstrumentationSystem``.
+**`withInstrument(_:_:)`: accept any `Instrument`.** Take any `Instrument`, not just a `Tracer`, so
+propagation-only tools could be scoped too. Rejected. A scope built around a propagation-only `Instrument` on
+its own is never useful. Span creation inside it silently finds no tracer and falls back to a ``NoOpTracer``,
+with no compiler warning. Narrowing the parameter to `Tracer` turns that mistake into a compile error instead.
 
-**Public `TaskLocalInstrument` to bootstrap directly.** Make `TaskLocalInstrument` a public type that
-applications bootstrap directly (`InstrumentationSystem.bootstrap(TaskLocalInstrument(tracer))`), entering
-scopes via a static `TaskLocalInstrument.with(_:_:)`. Rejected: a single free function matches the `withSpan`
-/ `withMetricsFactory` precedent and avoids forcing a plain-vs-wrapped choice at bootstrap and compatibilities
-with libraries doing instrumentation.
+**A task-local-aware instrument installed as the bootstrap.** Instead of ``InstrumentationSystem`` reading a
+task-local directly, install a dedicated wrapper instrument as the bootstrap that holds the task-local and
+falls back to an inner ``NoOpInstrument``. This keeps the task-local read off the resolution path for
+applications that only ``InstrumentationSystem/bootstrap(_:)`` and never scope. Rejected. It couples
+``withTracer(_:_:)`` to the bootstrap state (it cannot be installed over a plainly-bootstrapped instrument),
+introduces a self-reference hazard when ``InstrumentationSystem/instrument`` is passed back in, and needs
+install-on-first-use. The always-checked slot is simpler and composes with any bootstrap.
+
+**Store the tracer inside `ServiceContext`, not a separate slot.** Save the scoped tracer as a value inside
+`ServiceContext` itself, alongside whatever it already carries, instead of on a dedicated task-local on
+``InstrumentationSystem``. Code that already threads an explicit `ServiceContext`, rather than relying on the
+ambient `ServiceContext.current`, gets the tracer propagated for free. That would also make it safe for an
+application to move fully from ``bootstrap(_:)`` to `withTracer(_:_:)`, since no branch of the call graph could
+silently lose the override. Rejected. It creates two public APIs, from two different packages, that can each
+change the active tracer: `withTracer(_:_:)`, and `ServiceContext`'s own `$current.withValue(_:)`. Only the
+first knows the tracer's key exists, so binding a freshly created `ServiceContext` through the second, an
+ordinary and legitimate thing to do, has no way to carry the current tracer forward, and silently drops it with
+no diagnostic. The separate task-local slot has the mirror problem, however. Some code manually saves and restores
+`ServiceContext.current` across a boundary outside the task hierarchy, an event loop callback, for example.
+That code restores the context, but not the tracer, because the two live in different places. Until someone
+updates it to restore the tracer too, spans on that branch use the bootstrapped tracer instead of the scoped
+one, which might not be installed at all.
 
 **Accumulate nested scopes instead of replacing.** Push onto a task-local stack so a nested scope adds to,
-rather than replaces, the enclosing one. Rejected: it is a hidden, surprising accumulation, and the use case
-it serves — augmenting whatever is already active — cannot be offered cleanly anyway, since
-``InstrumentationSystem/instrument`` is a scope-aware wrapper rather than a concrete value (see above).
-Replacing is simpler and matches swift-metrics' `withMetricsFactory`. Pass a ``MultiplexInstrument`` to run
-several instruments at once.
+rather than replaces, the enclosing one. Rejected. It is a hidden, surprising accumulation, and replacing is
+simpler and easier to reason about.
 
-**Task-local ``Tracer`` only.** Rejected: leaves ``InstrumentationSystem/instrument`` global, so `extract` /
-`inject` wouldn't see the scope — a test would capture spans but miss incoming trace IDs.
+**Expose `bootstrapInternal` for tests.** Rejected. It solves only testing, keeps the one-shot global model,
+and gives libraries no per-request scoping.
 
-**Expose `bootstrapInternal` for tests.** Rejected: solves only testing, keeps the one-shot global model, and
-gives libraries no per-request scoping.
-
-**Pass the instrument to the closure** (`withInstrument(x) { x in … }`). Rejected: library code uses
-``InstrumentationSystem/instrument`` and `withSpan`, not the instrument directly. Passing it would push people
+**Pass the tracer to the closure** (`withTracer(x) { x in … }`). Rejected. Library code uses
+``InstrumentationSystem/instrument`` and `withSpan`, not the tracer directly, and passing it would push people
 toward direct use.

--- a/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-tracer.md
+++ b/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-tracer.md
@@ -1,4 +1,4 @@
-# SDT-0001: task-local instrument
+# SDT-0001: task-local tracer
 
 A ``withTracer(_:_:)`` free function that binds a ``Tracer`` to the current task. It takes priority over the
 process-wide ``InstrumentationSystem/bootstrap(_:)`` for the scope, then falls back to it.

--- a/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-tracer.md
+++ b/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-tracer.md
@@ -7,7 +7,7 @@ process-wide ``InstrumentationSystem/bootstrap(_:)`` for the scope, then falls b
 
 - Proposal: SDT-0001
 - Author(s): [Vladimir Kukushkin](https://github.com/kukushechkin)
-- Status: **In Review**
+- Status: **Ready for Implementation**
 - Issue: [apple/swift-distributed-tracing#168](https://github.com/apple/swift-distributed-tracing/issues/168)
 - Implementation: on the `SDT-0001-task-local-instrument-implementation` branch
 

--- a/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-tracer.md
+++ b/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-tracer.md
@@ -1,6 +1,6 @@
 # SDT-0001: task-local tracer
 
-A ``withTracer(_:_:)`` free function that binds a ``Tracer`` to the current task. It takes priority over the
+A `withTracer(_:_:)` free function that binds a ``Tracer`` to the current task. It takes priority over the
 process-wide ``InstrumentationSystem/bootstrap(_:)`` for the scope, then falls back to it.
 
 ## Overview
@@ -13,9 +13,9 @@ process-wide ``InstrumentationSystem/bootstrap(_:)`` for the scope, then falls b
 
 ### Introduction
 
-This proposal adds the ``withTracer(_:_:)`` free function. It runs a closure with a chosen ``Tracer`` active
+This proposal adds the `withTracer(_:_:)` free function. It runs a closure with a chosen ``Tracer`` active
 for the current task and any child tasks it spawns. Unlike ``InstrumentationSystem/bootstrap(_:)``, which is
-set once per process, ``withTracer(_:_:)`` can bind a different tracer per region of work, for example per test.
+set once per process, `withTracer(_:_:)` can bind a different tracer per region of work, for example per test.
 
 ### Motivation
 
@@ -26,7 +26,7 @@ instrument. This fits "one tracer for the whole application." Per-test tracers a
 
 ### Proposed solution
 
-``withTracer(_:_:)`` runs a closure with a tracer active for the current task:
+`withTracer(_:_:)` runs a closure with a tracer active for the current task:
 
 ```swift
 // Parallel-safe unit test. The binding is task-local, so concurrent tests don't interfere.
@@ -43,9 +43,9 @@ Inside the closure, and in any child tasks it spawns, `tracer` is the active ins
 (``InstrumentationSystem/tracer``, `withSpan` / `startSpan`) and propagation (`inject` / `extract`) give it
 priority over whatever ``InstrumentationSystem/bootstrap(_:)`` set, because a ``Tracer`` is an ``Instrument``.
 Outside the closure, or in tasks that don't inherit the binding, resolution falls back to the bootstrapped
-instrument. Nesting ``withTracer(_:_:)`` overrides `tracer` for the inner scope only.
+instrument. Nesting `withTracer(_:_:)` overrides `tracer` for the inner scope only.
 
-``withTracer(_:_:)`` only accepts a ``Tracer``, not an arbitrary ``Instrument``. `MultiplexInstrument` is not
+`withTracer(_:_:)` only accepts a ``Tracer``, not an arbitrary ``Instrument``. `MultiplexInstrument` is not
 a `Tracer` either, so while several tools can still be installed together at
 ``InstrumentationSystem/bootstrap(_:)`` for the whole process, there is no supported way to combine them
 within one task-local scope, see Future directions.
@@ -130,7 +130,7 @@ that task-local first, and only read the bootstrapped instrument if it is not se
 ### API stability
 
 - Purely additive: a new free function and an internal task-local. Existing signatures are unchanged.
-- Applications that never call ``withTracer(_:_:)`` see no behavioral change. Instrument lookup now checks a
+- Applications that never call `withTracer(_:_:)` see no behavioral change. Instrument lookup now checks a
   task-local before falling back to the bootstrapped instrument.
 - That task-local read happens on every lookup, including the per-span `withSpan` / `startSpan` path. An
   application that only calls ``bootstrap(_:)`` pays for this extra check every time, negligible next to what a
@@ -139,10 +139,10 @@ that task-local first, and only read the bootstrapped instrument if it is not se
 
 ### Future directions
 
-- **Combining several tools in one scope.** ``withTracer(_:_:)`` only takes one `Tracer`. There is no built-in
+- **Combining several tools in one scope.** `withTracer(_:_:)` only takes one `Tracer`. There is no built-in
   way to task-locally combine a tracer with extra propagators, or several tracers at once. A wrapper type
   that groups several instruments behind one `Tracer` conformance, something like a `MultiplexTracer`, could
-  close this gap without changing ``withTracer(_:_:)`` itself.
+  close this gap without changing `withTracer(_:_:)` itself.
 
 ### Alternatives considered
 
@@ -155,7 +155,7 @@ with no compiler warning. Narrowing the parameter to `Tracer` turns that mistake
 task-local directly, install a dedicated wrapper instrument as the bootstrap that holds the task-local and
 falls back to an inner ``NoOpInstrument``. This keeps the task-local read off the resolution path for
 applications that only ``InstrumentationSystem/bootstrap(_:)`` and never scope. Rejected. It couples
-``withTracer(_:_:)`` to the bootstrap state (it cannot be installed over a plainly-bootstrapped instrument),
+`withTracer(_:_:)` to the bootstrap state (it cannot be installed over a plainly-bootstrapped instrument),
 introduces a self-reference hazard when ``InstrumentationSystem/instrument`` is passed back in, and needs
 install-on-first-use. The always-checked slot is simpler and composes with any bootstrap.
 

--- a/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-tracer.md
+++ b/Sources/Tracing/Docs.docc/Proposals/SDT-0001-task-local-tracer.md
@@ -1,7 +1,7 @@
 # SDT-0001: task-local tracer
 
-A `withTracer(_:_:)` free function that binds a ``Tracer`` to the current task. It takes priority over the
-process-wide ``InstrumentationSystem/bootstrap(_:)`` for the scope, then falls back to it.
+A `withTracer(_:_:)` free function that binds a `Tracer` to the current task. It takes priority over the
+process-wide `InstrumentationSystem/bootstrap(_:)` for the scope, then falls back to it.
 
 ## Overview
 
@@ -13,14 +13,14 @@ process-wide ``InstrumentationSystem/bootstrap(_:)`` for the scope, then falls b
 
 ### Introduction
 
-This proposal adds the `withTracer(_:_:)` free function. It runs a closure with a chosen ``Tracer`` active
-for the current task and any child tasks it spawns. Unlike ``InstrumentationSystem/bootstrap(_:)``, which is
+This proposal adds the `withTracer(_:_:)` free function. It runs a closure with a chosen `Tracer` active
+for the current task and any child tasks it spawns. Unlike `InstrumentationSystem/bootstrap(_:)`, which is
 set once per process, `withTracer(_:_:)` can bind a different tracer per region of work, for example per test.
 
 ### Motivation
 
-``InstrumentationSystem/bootstrap(_:)`` installs an instrument **once** per process. From then on, every
-`withSpan` / `startSpan` call and every read of ``InstrumentationSystem/instrument`` resolves through that one
+`InstrumentationSystem/bootstrap(_:)` installs an instrument **once** per process. From then on, every
+`withSpan` / `startSpan` call and every read of `InstrumentationSystem/instrument` resolves through that one
 instrument. This fits "one tracer for the whole application." Per-test tracers are hard, though. A second
 `bootstrap` call crashes, so parallel tests can't each install their own.
 
@@ -40,14 +40,14 @@ instrument. This fits "one tracer for the whole application." Per-test tracers a
 ```
 
 Inside the closure, and in any child tasks it spawns, `tracer` is the active instrument. Span creation
-(``InstrumentationSystem/tracer``, `withSpan` / `startSpan`) and propagation (`inject` / `extract`) give it
-priority over whatever ``InstrumentationSystem/bootstrap(_:)`` set, because a ``Tracer`` is an ``Instrument``.
+(`InstrumentationSystem/tracer`, `withSpan` / `startSpan`) and propagation (`inject` / `extract`) give it
+priority over whatever `InstrumentationSystem/bootstrap(_:)` set, because a `Tracer` is an `Instrument`.
 Outside the closure, or in tasks that don't inherit the binding, resolution falls back to the bootstrapped
 instrument. Nesting `withTracer(_:_:)` overrides `tracer` for the inner scope only.
 
-`withTracer(_:_:)` only accepts a ``Tracer``, not an arbitrary ``Instrument``. `MultiplexInstrument` is not
+`withTracer(_:_:)` only accepts a `Tracer`, not an arbitrary `Instrument`. `MultiplexInstrument` is not
 a `Tracer` either, so while several tools can still be installed together at
-``InstrumentationSystem/bootstrap(_:)`` for the whole process, there is no supported way to combine them
+`InstrumentationSystem/bootstrap(_:)` for the whole process, there is no supported way to combine them
 within one task-local scope, see Future directions.
 
 ### Detailed design
@@ -56,14 +56,14 @@ within one task-local scope, see Future directions.
 /// Makes `tracer` the active instrument for the current task and the child tasks it spawns, for the
 /// duration of `operation`.
 ///
-/// ``InstrumentationSystem/instrument``, ``InstrumentationSystem/tracer``, `withSpan` / `startSpan`, and
-/// propagation (`inject` / `extract`) all favor `tracer` over whatever ``InstrumentationSystem/bootstrap(_:)``
+/// `InstrumentationSystem/instrument`, `InstrumentationSystem/tracer`, `withSpan` / `startSpan`, and
+/// propagation (`inject` / `extract`) all favor `tracer` over whatever `InstrumentationSystem/bootstrap(_:)`
 /// set. An unstructured `Task { }` inherits the binding. `Task.detached` does not. Nesting
 /// `withTracer(_:_:)` overrides `tracer` for the inner scope only.
 ///
 /// Checks the task-local first, and only reads the bootstrapped instrument if it is not set. A resolution
 /// inside this scope returns from the task-local directly and never touches the bootstrapped storage. An
-/// application that only calls ``InstrumentationSystem/bootstrap(_:)`` pays for that extra check on
+/// application that only calls `InstrumentationSystem/bootstrap(_:)` pays for that extra check on
 /// every lookup.
 ///
 /// ```swift
@@ -77,8 +77,8 @@ within one task-local scope, see Future directions.
 /// }
 /// ```
 ///
-/// A ``Tracer`` is also an ``Instrument``, so this replaces propagation too, not just span creation. To keep
-/// several tools active at once, install a ``MultiplexInstrument`` at ``InstrumentationSystem/bootstrap(_:)``.
+/// A `Tracer` is also an `Instrument`, so this replaces propagation too, not just span creation. To keep
+/// several tools active at once, install a `MultiplexInstrument` at `InstrumentationSystem/bootstrap(_:)`.
 ///
 /// - Parameters:
 ///   - tracer: The tracer to make active for the duration of `operation`.
@@ -122,9 +122,9 @@ public func withTracer<Result, Failure: Error>(
 #endif
 ````
 
-The scope is backed by an `@TaskLocal` on ``InstrumentationSystem`` typed `(any Instrument)?`. There is no
-wrapper instrument, and nothing is installed on first use. ``InstrumentationSystem/instrument`` and the other
-resolution methods (``InstrumentationSystem/tracer``, ``InstrumentationSystem/_findInstrument(where:)``) check
+The scope is backed by an `@TaskLocal` on `InstrumentationSystem` typed `(any Instrument)?`. There is no
+wrapper instrument, and nothing is installed on first use. `InstrumentationSystem/instrument` and the other
+resolution methods (`InstrumentationSystem/tracer`, `InstrumentationSystem/_findInstrument(where:)`) check
 that task-local first, and only read the bootstrapped instrument if it is not set.
 
 ### API stability
@@ -133,7 +133,7 @@ that task-local first, and only read the bootstrapped instrument if it is not se
 - Applications that never call `withTracer(_:_:)` see no behavioral change. Instrument lookup now checks a
   task-local before falling back to the bootstrapped instrument.
 - That task-local read happens on every lookup, including the per-span `withSpan` / `startSpan` path. An
-  application that only calls ``bootstrap(_:)`` pays for this extra check every time, negligible next to what a
+  application that only calls `bootstrap(_:)` pays for this extra check every time, negligible next to what a
   real tracer already does per span. A resolution inside `withTracer(_:_:)` returns from the task-local
   directly, and never reads the bootstrapped storage at all.
 
@@ -148,22 +148,22 @@ that task-local first, and only read the bootstrapped instrument if it is not se
 
 **`withInstrument(_:_:)`: accept any `Instrument`.** Take any `Instrument`, not just a `Tracer`, so
 propagation-only tools could be scoped too. Rejected. A scope built around a propagation-only `Instrument` on
-its own is never useful. Span creation inside it silently finds no tracer and falls back to a ``NoOpTracer``,
+its own is never useful. Span creation inside it silently finds no tracer and falls back to a `NoOpTracer`,
 with no compiler warning. Narrowing the parameter to `Tracer` turns that mistake into a compile error instead.
 
-**A task-local-aware instrument installed as the bootstrap.** Instead of ``InstrumentationSystem`` reading a
+**A task-local-aware instrument installed as the bootstrap.** Instead of `InstrumentationSystem` reading a
 task-local directly, install a dedicated wrapper instrument as the bootstrap that holds the task-local and
-falls back to an inner ``NoOpInstrument``. This keeps the task-local read off the resolution path for
-applications that only ``InstrumentationSystem/bootstrap(_:)`` and never scope. Rejected. It couples
+falls back to an inner `NoOpInstrument`. This keeps the task-local read off the resolution path for
+applications that only `InstrumentationSystem/bootstrap(_:)` and never scope. Rejected. It couples
 `withTracer(_:_:)` to the bootstrap state (it cannot be installed over a plainly-bootstrapped instrument),
-introduces a self-reference hazard when ``InstrumentationSystem/instrument`` is passed back in, and needs
+introduces a self-reference hazard when `InstrumentationSystem/instrument` is passed back in, and needs
 install-on-first-use. The always-checked slot is simpler and composes with any bootstrap.
 
 **Store the tracer inside `ServiceContext`, not a separate slot.** Save the scoped tracer as a value inside
 `ServiceContext` itself, alongside whatever it already carries, instead of on a dedicated task-local on
-``InstrumentationSystem``. Code that already threads an explicit `ServiceContext`, rather than relying on the
+`InstrumentationSystem`. Code that already threads an explicit `ServiceContext`, rather than relying on the
 ambient `ServiceContext.current`, gets the tracer propagated for free. That would also make it safe for an
-application to move fully from ``bootstrap(_:)`` to `withTracer(_:_:)`, since no branch of the call graph could
+application to move fully from `bootstrap(_:)` to `withTracer(_:_:)`, since no branch of the call graph could
 silently lose the override. Rejected. It creates two public APIs, from two different packages, that can each
 change the active tracer: `withTracer(_:_:)`, and `ServiceContext`'s own `$current.withValue(_:)`. Only the
 first knows the tracer's key exists, so binding a freshly created `ServiceContext` through the second, an
@@ -182,5 +182,5 @@ simpler and easier to reason about.
 and gives libraries no per-request scoping.
 
 **Pass the tracer to the closure** (`withTracer(x) { x in … }`). Rejected. Library code uses
-``InstrumentationSystem/instrument`` and `withSpan`, not the tracer directly, and passing it would push people
+`InstrumentationSystem/instrument` and `withSpan`, not the tracer directly, and passing it would push people
 toward direct use.


### PR DESCRIPTION
This proposal adds a `withTracer(_:_:)` for task-local tracer scoping.

## Motivation:

`InstrumentationSystem.bootstrap(_:)` installs an instrument once per process, so every `withSpan`/`startSpan` and every read of `InstrumentationSystem.instrument` resolves through that single instrument. That fits one tracer for the whole application, but it leaves no way to bind a different tracer for a region of work — most acutely in tests, where a second `bootstrap` crashes and parallel tests cannot each install their own in-memory tracer.

## Modifications:

SDT-0001 proposal is added.

## Result:

SDT-0001 proposal is ready for review.