### PR TITLE
Fix MultiplexInstrument tracer fan-out

### DIFF
--- a/Sources/Instrumentation/MultiplexInstrument.swift
+++ b/Sources/Instrumentation/MultiplexInstrument.swift
@@ -33,6 +33,10 @@ extension MultiplexInstrument {
     func firstInstrument(where predicate: (Instrument) -> Bool) -> Instrument? {
         self.instruments.first(where: predicate)
     }
+
+    package func matchingInstruments(where predicate: (Instrument) -> Bool) -> [Instrument] {
+        self.instruments.filter(predicate)
+    }
 }
 
 extension MultiplexInstrument: Instrument {

--- a/Sources/Tracing/InstrumentationSystem+Tracing.swift
+++ b/Sources/Tracing/InstrumentationSystem+Tracing.swift
@@ -16,13 +16,30 @@
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension InstrumentationSystem {
+    private static var multiplexTracer: MultiplexTracer? {
+        guard let multiplex = self.instrument as? MultiplexInstrument else { return nil }
+
+        let tracers =
+            multiplex
+            .matchingInstruments(where: { $0 is any LegacyTracer })
+            .compactMap { $0 as? any LegacyTracer }
+
+        guard tracers.count > 1 else { return nil }
+        return MultiplexTracer(tracers)
+    }
+
     /// Returns the ``Tracer`` bootstrapped as part of the `InstrumentationSystem`.
     ///
-    /// If the system was bootstrapped with a `MultiplexInstrument` this function attempts to locate the _first_
-    /// tracing instrument as passed to the multiplex instrument. If none is found, a ``NoOpTracer`` is returned.
+    /// If the system was bootstrapped with a `MultiplexInstrument` containing multiple tracing instruments, this
+    /// function returns a tracer that forwards span operations to each of them. If none is found, a ``NoOpTracer``
+    /// is returned.
     ///
     /// - Returns: A ``Tracer`` if the system was bootstrapped with one, and ``NoOpTracer`` otherwise.
     public static var tracer: any Tracer {
+        if let multiplexTracer = self.multiplexTracer {
+            return multiplexTracer
+        }
+
         let found: (any Tracer)? =
             (self._findInstrument(where: { $0 is (any Tracer) }) as? (any Tracer))
         return found ?? NoOpTracer()
@@ -30,12 +47,17 @@ extension InstrumentationSystem {
 
     /// Returns the ``Tracer`` bootstrapped as part of the `InstrumentationSystem`.
     ///
-    /// If the system was bootstrapped with a `MultiplexInstrument` this function attempts to locate the _first_
-    /// tracing instrument as passed to the multiplex instrument. If none is found, a ``NoOpTracer`` is returned.
+    /// If the system was bootstrapped with a `MultiplexInstrument` containing multiple tracing instruments, this
+    /// function returns a tracer that forwards span operations to each of them. If none is found, a ``NoOpTracer``
+    /// is returned.
     ///
     /// - Returns: A ``Tracer`` if the system was bootstrapped with one, and ``NoOpTracer`` otherwise.
     @available(*, deprecated, message: "prefer tracer")
     public static var legacyTracer: any LegacyTracer {
+        if let multiplexTracer = self.multiplexTracer {
+            return multiplexTracer
+        }
+
         let found: (any LegacyTracer)? =
             (self._findInstrument(where: { $0 is (any LegacyTracer) }) as? (any LegacyTracer))
         return found ?? NoOpTracer()

--- a/Sources/Tracing/MultiplexTracer.swift
+++ b/Sources/Tracing/MultiplexTracer.swift
@@ -1,0 +1,182 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Distributed Tracing open source project
+//
+// Copyright (c) 2020-2023 Apple Inc. and the Swift Distributed Tracing project authors
+// Licensed under Apache License 2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Distributed Tracing project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Instrumentation
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+package final class MultiplexSpan: Span, @unchecked Sendable {
+    private let spans: [any Span]
+
+    package init(_ spans: [any Span]) {
+        precondition(!spans.isEmpty, "A multiplex span must contain at least one span")
+        self.spans = spans
+    }
+
+    package var context: ServiceContext {
+        self.spans[0].context
+    }
+
+    package var operationName: String {
+        get { self.spans[0].operationName }
+        set {
+            for span in self.spans {
+                span.operationName = newValue
+            }
+        }
+    }
+
+    package func setStatus(_ status: SpanStatus) {
+        for span in self.spans {
+            span.setStatus(status)
+        }
+    }
+
+    package func addEvent(_ event: SpanEvent) {
+        for span in self.spans {
+            span.addEvent(event)
+        }
+    }
+
+    package func recordError<Instant: TracerInstant>(
+        _ error: Error,
+        attributes: SpanAttributes,
+        at instant: @autoclosure () -> Instant
+    ) {
+        let resolvedInstant = instant()
+        for span in self.spans {
+            span.recordError(error, attributes: attributes, at: resolvedInstant)
+        }
+    }
+
+    package var attributes: SpanAttributes {
+        get { self.spans[0].attributes }
+        set {
+            for span in self.spans {
+                span.attributes = newValue
+            }
+        }
+    }
+
+    package var isRecording: Bool {
+        self.spans.contains(where: { $0.isRecording })
+    }
+
+    package func addLink(_ link: SpanLink) {
+        for span in self.spans {
+            span.addLink(link)
+        }
+    }
+
+    package func end<Instant: TracerInstant>(at instant: @autoclosure () -> Instant) {
+        let resolvedInstant = instant()
+        for span in self.spans {
+            span.end(at: resolvedInstant)
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+package final class MultiplexTracer: Tracer {
+    package typealias Span = MultiplexSpan
+
+    private let tracers: [any LegacyTracer]
+
+    package init(_ tracers: [any LegacyTracer]) {
+        precondition(tracers.count > 1, "A multiplex tracer must contain multiple tracers")
+        self.tracers = tracers
+    }
+
+    package func inject<Carrier, Inject>(_ context: ServiceContext, into carrier: inout Carrier, using injector: Inject)
+    where Inject: Injector, Carrier == Inject.Carrier {
+        for tracer in self.tracers {
+            tracer.inject(context, into: &carrier, using: injector)
+        }
+    }
+
+    package func extract<Carrier, Extract>(
+        _ carrier: Carrier,
+        into context: inout ServiceContext,
+        using extractor: Extract
+    )
+    where Extract: Extractor, Carrier == Extract.Carrier {
+        for tracer in self.tracers {
+            tracer.extract(carrier, into: &context, using: extractor)
+        }
+    }
+
+    package func startAnySpan<Instant: TracerInstant>(
+        _ operationName: String,
+        context: @autoclosure () -> ServiceContext,
+        ofKind kind: SpanKind,
+        at instant: @autoclosure () -> Instant,
+        function: String,
+        file fileID: String,
+        line: UInt
+    ) -> any Tracing.Span {
+        let resolvedContext = context()
+        let resolvedInstant = instant()
+        let spans = self.tracers.map { tracer in
+            tracer.startAnySpan(
+                operationName,
+                context: resolvedContext,
+                ofKind: kind,
+                at: resolvedInstant,
+                function: function,
+                file: fileID,
+                line: line
+            )
+        }
+        return MultiplexSpan(spans)
+    }
+
+    package func startSpan<Instant: TracerInstant>(
+        _ operationName: String,
+        context: @autoclosure () -> ServiceContext,
+        ofKind kind: SpanKind,
+        at instant: @autoclosure () -> Instant,
+        function: String,
+        file fileID: String,
+        line: UInt
+    ) -> MultiplexSpan {
+        let resolvedContext = context()
+        let resolvedInstant = instant()
+        let spans = self.tracers.map { tracer in
+            tracer.startAnySpan(
+                operationName,
+                context: resolvedContext,
+                ofKind: kind,
+                at: resolvedInstant,
+                function: function,
+                file: fileID,
+                line: line
+            )
+        }
+        return MultiplexSpan(spans)
+    }
+
+    package func activeSpan(identifiedBy context: ServiceContext) -> MultiplexSpan? {
+        let spans = self.tracers.compactMap { tracer -> (any Tracing.Span)? in
+            guard let tracer = tracer as? any Tracer else { return nil }
+            return tracer.activeSpan(identifiedBy: context)
+        }
+        guard !spans.isEmpty else { return nil }
+        return MultiplexSpan(spans)
+    }
+
+    package func forceFlush() {
+        for tracer in self.tracers {
+            tracer.forceFlush()
+        }
+    }
+}

--- a/Tests/TracingTests/TracingInstrumentationSystemTests.swift
+++ b/Tests/TracingTests/TracingInstrumentationSystemTests.swift
@@ -68,6 +68,35 @@ struct GlobalTracingInstrumentationSystemTests {
         #expect(InstrumentationSystem.tracer is TestTracer)
     }
 
+    @Test("Multiplex tracing forwards spans to every tracer")
+    func multiplexTracingForwardsSpansToEveryTracer() {
+        InstrumentationSystem.bootstrapInternal(nil)
+        defer { InstrumentationSystem.bootstrapInternal(nil) }
+
+        let firstTracer = TestTracer()
+        let secondTracer = TestTracer()
+        InstrumentationSystem.bootstrapInternal(MultiplexInstrument([firstTracer, secondTracer]))
+
+        let span = InstrumentationSystem.tracer.startSpan(
+            "multiplexed-span",
+            context: .topLevel,
+            ofKind: .internal,
+            at: DefaultTracerClock.now,
+            function: #function,
+            file: #fileID,
+            line: #line
+        )
+        span.end()
+
+        #expect(firstTracer.spans.count == 1)
+        #expect(secondTracer.spans.count == 1)
+
+        withSpan("multiplexed-global-span") { _ in }
+
+        #expect(firstTracer.spans.count == 2)
+        #expect(secondTracer.spans.count == 2)
+    }
+
     @Test("Global tracing methods preserve arguments")
     func globalTracingMethods() async throws {
         // Clean state before test


### PR DESCRIPTION
Fixes #232

MultiplexInstrument now forwards span creation and span lifecycle operations to every configured tracer, including context propagation, attributes, events, errors, links, status, flush, and end. This adds direct and global instrumentation coverage for multiple tracers.

Validation:
swift test
git diff --check